### PR TITLE
Disable EVM wallets in Privy config

### DIFF
--- a/components/ClientOnlyPrivyWrapper.js
+++ b/components/ClientOnlyPrivyWrapper.js
@@ -6,9 +6,17 @@ import { PrivyProvider } from '@privy-io/react-auth'
 // Privy configuration
 const privyConfig = {
   embeddedWallets: {
-    createOnLogin: 'users-without-wallets',
+    solana: { createOnLogin: 'users-without-wallets' },
+    evm: { createOnLogin: 'none' },
     noPromptOnSignature: false
   },
+  externalWallets: {
+    solana: { wallets: ['phantom', 'solflare', 'backpack'] }
+  },
+  solanaClusters: [
+    { name: 'mainnet-beta', rpcUrl: 'https://api.mainnet-beta.solana.com' }
+  ],
+  smartWallets: { enabled: false },
   loginMethods: ['email', 'google', 'discord'],
   appearance: {
     theme: 'dark',

--- a/components/providers/PrivyAuthProvider.js
+++ b/components/providers/PrivyAuthProvider.js
@@ -211,18 +211,19 @@ export default function PrivyAuthProvider({ children }) {
     loginMethods: ['google', 'email', 'wallet'],
     // Solana-only embedded wallets configuration
     embeddedWallets: {
-      createOnLogin: 'users-without-wallets', // Global setting
-      solana: { 
-        createOnLogin: 'users-without-wallets' 
+      solana: {
+        createOnLogin: 'users-without-wallets'
+      },
+      // Explicitly disable EVM wallets
+      evm: {
+        createOnLogin: 'none'
       }
-      // Explicitly NO evm section to disable EVM wallets
     },
     // External Solana wallets support
     externalWallets: {
-      solana: { 
-        wallets: ['phantom', 'solflare', 'backpack'] 
+      solana: {
+        wallets: ['phantom', 'solflare', 'backpack']
       }
-      // Explicitly NO evm section to disable EVM wallets
     },
     // Solana clusters configuration
     solanaClusters: [

--- a/components/providers/PrivyProvider.js
+++ b/components/providers/PrivyProvider.js
@@ -26,8 +26,16 @@ export default function PrivyAuthProvider({ children }) {
     },
     loginMethods: ['email', 'wallet'],
     embeddedWallets: {
-      createOnLogin: 'users-without-wallets',
+      solana: { createOnLogin: 'users-without-wallets' },
+      evm: { createOnLogin: 'none' },
     },
+    externalWallets: {
+      solana: { wallets: ['phantom', 'solflare', 'backpack'] },
+    },
+    solanaClusters: [
+      { name: 'mainnet-beta', rpcUrl: 'https://api.mainnet-beta.solana.com' }
+    ],
+    smartWallets: { enabled: false },
   }
 
   return (


### PR DESCRIPTION
## Summary
- restrict embedded wallet creation to Solana and disable EVM wallets
- align all Privy provider wrappers with Solana-only settings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: parsing and undefined errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a5ebefbc833096d1565eacbd53d6