### PR TITLE
Ensure Colyseus server builds before start

### DIFF
--- a/colyseus-server/package.json
+++ b/colyseus-server/package.json
@@ -4,6 +4,7 @@
   "description": "TurfLoot multiplayer game server using Colyseus",
   "main": "lib/index.js",
   "scripts": {
+    "prestart": "npm run build",
     "start": "node lib/index.js",
     "build": "tsc",
     "dev": "ts-node-esm src/index.ts"


### PR DESCRIPTION
## Summary
- add a prestart hook to run the TypeScript build before launching the Colyseus server

## Testing
- npm --prefix colyseus-server run build *(fails: existing TypeScript compilation errors in src/)*

------
https://chatgpt.com/codex/tasks/task_e_68ce9ce0b14083309ebb0dfa60cf124d