### PR TITLE
Ensure Colyseus session metadata reaches gameplay

### DIFF
--- a/components/ServerBrowserModalNew.jsx
+++ b/components/ServerBrowserModalNew.jsx
@@ -397,7 +397,10 @@ const ServerBrowserModal = ({ isOpen, onClose, onJoinLobby }) => {
       maxPlayers: room.maxPlayers,
       currentPlayers: room.currentPlayers,
       isActive: room.isActive,
-      canSpectate: room.canSpectate
+      canSpectate: room.canSpectate,
+      colyseusRoomId: room.colyseusRoomId || room.id,
+      colyseusEndpoint: room.colyseusEndpoint || room.endpoint,
+      joinMetadata: room.joinMetadata || room.metadata || null
     }
     
     console.log('🎮 HANDLEJOINSERVER: Processed room data for join:', serverData)


### PR DESCRIPTION
## Summary
- carry the actual Colyseus room identifier and related join metadata through the lobby navigation flow so the gameplay route can see it
- capture session identifiers after joining a Colyseus arena and post them to the game session API with the fee, mode, region, and unique player identifier
- include Colyseus join metadata in the server browser payload when launching a room

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d033fcb3888330840ced32dcd630c5