### PR TITLE
Ensure multiplayer globals track React state

### DIFF
--- a/app/agario/page.js
+++ b/app/agario/page.js
@@ -59,6 +59,15 @@ const AgarIOGame = () => {
   const [statsExpanded, setStatsExpanded] = useState(false)
   const statsTimerRef = useRef(null)
 
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    window.isMultiplayer = isMultiplayer
+    window.getIsMultiplayer = () => window.isMultiplayer
+  }, [isMultiplayer])
+
   // Auto-collapse leaderboard after 5 seconds of no interaction
   useEffect(() => {
     if (leaderboardExpanded && isMobile) {

--- a/frontend/app/agario/page.js
+++ b/frontend/app/agario/page.js
@@ -59,6 +59,15 @@ const AgarIOGame = () => {
   const [statsExpanded, setStatsExpanded] = useState(false)
   const statsTimerRef = useRef(null)
 
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    window.isMultiplayer = isMultiplayer
+    window.getIsMultiplayer = () => window.isMultiplayer
+  }, [isMultiplayer])
+
   // Auto-collapse leaderboard after 5 seconds of no interaction
   useEffect(() => {
     if (leaderboardExpanded && isMobile) {


### PR DESCRIPTION
## Summary
- keep the global multiplayer flag in sync with the React state in the Agar.io page
- mirror the same synchronization logic in the duplicated frontend page so GameEngine can detect multiplayer mode reliably

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0b8a2d4308330b5d6af435f0369ec