### PR TITLE
Align arena visuals with local Agar.io mode

### DIFF
--- a/app/arena/page.js
+++ b/app/arena/page.js
@@ -201,7 +201,7 @@ const MultiplayerArena = () => {
   useEffect(() => {
     if (isCashingOut && !cashOutComplete) {
       console.log('Starting cash out progress interval')
-      
+
       cashOutIntervalRef.current = setInterval(() => {
         setCashOutProgress(prev => {
           const newProgress = prev + 2 // 2% per 100ms = 5 second duration
@@ -231,6 +231,17 @@ const MultiplayerArena = () => {
       }
     }
   }, [isCashingOut, score])
+
+  // Sync cash out visuals with game engine rendering
+  useEffect(() => {
+    if (gameRef.current?.updateGameStates) {
+      gameRef.current.updateGameStates({
+        isCashingOut,
+        cashOutProgress,
+        cashOutComplete
+      })
+    }
+  }, [isCashingOut, cashOutProgress, cashOutComplete])
 
   // Auto-collapse leaderboard after 5 seconds of no interaction
   useEffect(() => {
@@ -613,7 +624,32 @@ const MultiplayerArena = () => {
       this.serverState = null
       this.lastUpdate = Date.now()
       this.gameStartTime = Date.now()
-      
+
+      // Match Agar.io dynamic zone defaults
+      this.isCashGame = false
+      this.realPlayerCount = 0
+      this.basePlayableRadius = 800
+      this.maxPlayableRadius = 1800
+      this.currentPlayableRadius = 1800
+      this.targetPlayableRadius = 1800
+
+      // Local game state mirrors for visual elements
+      this.gameStates = {
+        isCashingOut: false,
+        cashOutProgress: 0,
+        cashOutComplete: false
+      }
+      this.updateGameStates = (updates = {}) => {
+        this.gameStates = { ...this.gameStates, ...updates }
+      }
+
+      // Maintain caches for animations and helper collections
+      this.enemies = []
+      this.coins = []
+      this.viruses = []
+      this.playerPieces = []
+      this.virusCache = new Map()
+
       this.bindEvents()
       this.setupMouse()
     }
@@ -673,25 +709,40 @@ const MultiplayerArena = () => {
     }
     
     updateFromServer(state) {
-      this.serverState = state
-      
+      const clonedPlayers = state.players ? state.players.map(player => ({ ...player })) : []
+      const mergedViruses = state.viruses
+        ? state.viruses.map(virus => {
+            const previous = this.virusCache.get(virus.id) || {}
+            const merged = { ...previous, ...virus }
+            this.virusCache.set(virus.id, merged)
+            return merged
+          })
+        : []
+
+      this.serverState = {
+        ...state,
+        players: clonedPlayers,
+        coins: state.coins ? state.coins.map(coin => ({ ...coin })) : [],
+        viruses: mergedViruses
+      }
+
       // Find ONLY the current player based on session ID - NO FALLBACK
-      let currentPlayer = state.players.find(p => p.isCurrentPlayer)
-      
+      const currentPlayer = clonedPlayers.find(p => p.isCurrentPlayer)
+
       if (currentPlayer) {
         // Verify this is actually our session to prevent camera jumping
         if (currentPlayer.sessionId === this.expectedSessionId) {
-          console.log('🎮 Camera following authenticated player:', currentPlayer.name, 
-                     'session:', currentPlayer.sessionId, 
+          console.log('🎮 Camera following authenticated player:', currentPlayer.name,
+                     'session:', currentPlayer.sessionId,
                      'at', currentPlayer.x?.toFixed(1), currentPlayer.y?.toFixed(1))
-          
+
           // Smooth position updates to prevent camera jumping
           if (this.player.x && this.player.y) {
             const distance = Math.sqrt(
-              Math.pow(currentPlayer.x - this.player.x, 2) + 
+              Math.pow(currentPlayer.x - this.player.x, 2) +
               Math.pow(currentPlayer.y - this.player.y, 2)
             )
-            
+
             // If the distance is large, apply directly (avoid desync)
             // If small, smooth interpolate to prevent jitter
             if (distance > 100) {
@@ -707,7 +758,13 @@ const MultiplayerArena = () => {
             this.player.x = currentPlayer.x
             this.player.y = currentPlayer.y
           }
-          
+
+          this.player.mass = currentPlayer.mass || this.player.mass
+          this.player.radius = currentPlayer.radius || this.player.radius
+          this.player.name = currentPlayer.name || this.player.name
+          this.player.color = currentPlayer.color || this.player.color
+          this.player.sessionId = currentPlayer.sessionId
+
           // Update mass and score
           setMass(Math.round(currentPlayer.mass) || 100)
           setScore(Math.round(currentPlayer.score) || 0)
@@ -777,200 +834,379 @@ const MultiplayerArena = () => {
     
     render() {
       if (!this.ctx || !this.running) return
-      
-      // Clear canvas with darker background matching 2nd image
-      this.ctx.fillStyle = '#1a1a1a' // Dark background like 2nd image
+
+      this.ctx.fillStyle = '#000000'
       this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height)
-      
-      // Save context for camera transform
+
       this.ctx.save()
       this.ctx.translate(-this.camera.x, -this.camera.y)
-      
-      // Draw world boundary with enhanced visuals
+
+      this.drawGrid()
       this.drawWorldBoundary()
-      
-      // Draw server state if available
+
       if (this.serverState) {
-        // Draw coins first (background layer)
-        this.serverState.coins.forEach(coin => {
-          this.drawCoin(coin)
-        })
-        
-        // Draw viruses (middle layer)
-        this.serverState.viruses.forEach(virus => {
-          this.drawVirus(virus)
-        })
-        
-        // Draw all players (foreground layer)
-        this.serverState.players.forEach(player => {
-          if (player.alive) {
-            this.drawPlayer(player, player.isCurrentPlayer)
+        const { coins = [], viruses = [], players = [] } = this.serverState
+
+        coins.forEach(coin => this.drawCoin(coin))
+        viruses.forEach(virus => this.drawVirus(virus))
+        players.forEach(player => {
+          if (player && player.alive !== false) {
+            const isMainPlayer = player.isCurrentPlayer || player.sessionId === this.expectedSessionId
+            this.drawPlayer(player, isMainPlayer)
           }
         })
       }
-      
+
       this.ctx.restore()
     }
-    
-    drawWorldBoundary() {
-      // Draw richer background matching 2nd image style
-      const gridSize = 25 // Smaller grid for denser pattern
-      this.ctx.strokeStyle = 'rgba(255, 255, 255, 0.05)'
+
+    drawGrid() {
+      this.ctx.strokeStyle = '#808080'
       this.ctx.lineWidth = 1
-      
-      // Vertical lines - denser grid
-      for (let x = 0; x <= this.world.width; x += gridSize) {
+      this.ctx.globalAlpha = 0.3
+
+      const gridSize = 50
+      const startX = Math.floor(this.camera.x / gridSize) * gridSize
+      const startY = Math.floor(this.camera.y / gridSize) * gridSize
+      const endX = startX + this.canvas.width + gridSize
+      const endY = startY + this.canvas.height + gridSize
+
+      for (let x = startX; x <= endX; x += gridSize) {
         this.ctx.beginPath()
-        this.ctx.moveTo(x, 0)
-        this.ctx.lineTo(x, this.world.height)
+        this.ctx.moveTo(x, startY)
+        this.ctx.lineTo(x, endY)
         this.ctx.stroke()
       }
-      
-      // Horizontal lines - denser grid  
-      for (let y = 0; y <= this.world.height; y += gridSize) {
+
+      for (let y = startY; y <= endY; y += gridSize) {
         this.ctx.beginPath()
-        this.ctx.moveTo(0, y)
-        this.ctx.lineTo(this.world.width, y)
+        this.ctx.moveTo(startX, y)
+        this.ctx.lineTo(endX, y)
         this.ctx.stroke()
       }
-      
-      // World border - bright green like 2nd image
-      this.ctx.strokeStyle = '#00ff00'
+
+      this.ctx.globalAlpha = 1.0
+    }
+
+    drawWorldBoundary() {
+      const centerX = this.world.width / 2
+      const centerY = this.world.height / 2
+      const playableRadius = this.currentPlayableRadius
+
+      this.ctx.fillStyle = '#1a0000'
+      this.ctx.fillRect(0, 0, this.world.width, this.world.height)
+
+      this.ctx.beginPath()
+      this.ctx.arc(centerX, centerY, playableRadius, 0, Math.PI * 2)
+      this.ctx.fillStyle = '#000000'
+      this.ctx.fill()
+
+      let zoneColor = '#00ff00'
+      if (Math.abs(this.currentPlayableRadius - this.targetPlayableRadius) > 1) {
+        zoneColor = '#ffff00'
+      }
+      if (this.isCashGame) {
+        zoneColor = this.targetPlayableRadius > this.currentPlayableRadius ? '#00ffff' : '#0080ff'
+      }
+
+      this.ctx.beginPath()
+      this.ctx.arc(centerX, centerY, playableRadius, 0, Math.PI * 2)
+      this.ctx.strokeStyle = zoneColor
       this.ctx.lineWidth = 8
-      this.ctx.strokeRect(0, 0, this.world.width, this.world.height)
-      
-      // Add inner border glow
-      this.ctx.strokeStyle = 'rgba(0, 255, 0, 0.3)'
-      this.ctx.lineWidth = 20
-      this.ctx.strokeRect(-10, -10, this.world.width + 20, this.world.height + 20)
+      this.ctx.stroke()
+
+      this.ctx.beginPath()
+      this.ctx.arc(centerX, centerY, playableRadius, 0, Math.PI * 2)
+      this.ctx.strokeStyle = zoneColor.replace(')', ', 0.6)')
+      this.ctx.lineWidth = 16
+      this.ctx.stroke()
+
+      this.ctx.beginPath()
+      this.ctx.arc(centerX, centerY, playableRadius, 0, Math.PI * 2)
+      this.ctx.strokeStyle = zoneColor.replace(')', ', 0.3)')
+      this.ctx.lineWidth = 24
+      this.ctx.stroke()
+
+      if (this.isCashGame && Math.abs(this.currentPlayableRadius - this.targetPlayableRadius) > 1) {
+        this.ctx.fillStyle = '#ffffff'
+        this.ctx.font = 'bold 16px Arial'
+        this.ctx.textAlign = 'center'
+        const direction = this.targetPlayableRadius > this.currentPlayableRadius ? 'EXPANDING' : 'SHRINKING'
+        this.ctx.fillText(`ZONE ${direction}`, centerX, centerY - playableRadius - 40)
+        this.ctx.font = 'bold 12px Arial'
+        this.ctx.fillText(`Players: ${this.realPlayerCount} | Radius: ${Math.floor(playableRadius)}`, centerX, centerY - playableRadius - 20)
+      }
     }
-    
+
     drawPlayer(player, isCurrentPlayer = false) {
-      const playerRadius = player.radius || 25
-      
-      // Player glow effect for current player
-      if (isCurrentPlayer) {
-        this.ctx.shadowColor = '#00BFFF'
-        this.ctx.shadowBlur = 20
-      }
-      
-      // Player circle with gradient
-      const gradient = this.ctx.createRadialGradient(
-        player.x, player.y, 0,
-        player.x, player.y, playerRadius
-      )
-      
-      if (isCurrentPlayer) {
-        gradient.addColorStop(0, '#00BFFF')  // Bright blue center
-        gradient.addColorStop(0.7, '#0080FF') // Medium blue
-        gradient.addColorStop(1, '#0040AA')   // Dark blue edge
-      } else {
-        gradient.addColorStop(0, '#FF6B6B')  // Red center for enemies
-        gradient.addColorStop(0.7, '#FF4444') // Medium red
-        gradient.addColorStop(1, '#CC2222')   // Dark red edge
-      }
-      
-      this.ctx.fillStyle = gradient
+      const radius = player.radius || Math.max(15, Math.sqrt(player.mass || 20) * 3)
+      const fillColor = player.color || (isCurrentPlayer ? '#4A90E2' : '#FF6B6B')
+
       this.ctx.beginPath()
-      this.ctx.arc(player.x, player.y, playerRadius, 0, Math.PI * 2)
+      this.ctx.arc(player.x, player.y, radius, 0, Math.PI * 2)
+      this.ctx.fillStyle = fillColor
       this.ctx.fill()
-      
-      // Remove shadow for border
-      this.ctx.shadowBlur = 0
-      
-      // Enhanced border
-      this.ctx.strokeStyle = isCurrentPlayer ? '#FFFFFF' : '#DDDDDD'
-      this.ctx.lineWidth = isCurrentPlayer ? 4 : 3
-      this.ctx.stroke()
-      
-      // Player name with better contrast
-      this.ctx.fillStyle = '#FFFFFF'
-      this.ctx.font = `bold ${Math.max(12, playerRadius * 0.5)}px "Rajdhani", sans-serif`
-      this.ctx.textAlign = 'center'
-      this.ctx.textBaseline = 'middle'
-      this.ctx.strokeStyle = '#000000'
-      this.ctx.lineWidth = 3
-      this.ctx.strokeText(player.name || 'Player', player.x, player.y)
-      this.ctx.fillText(player.name || 'Player', player.x, player.y)
-    }
-    
-    drawCoin(coin) {
-      // Enhanced coin rendering matching 2nd image density
-      const coinSize = coin.radius || 6
-      
-      // Main coin body with gradient
-      const gradient = this.ctx.createRadialGradient(coin.x, coin.y, 0, coin.x, coin.y, coinSize)
-      gradient.addColorStop(0, '#FFD700')
-      gradient.addColorStop(0.7, '#FFA500')
-      gradient.addColorStop(1, '#FF8C00')
-      
-      this.ctx.fillStyle = gradient
-      this.ctx.beginPath()
-      this.ctx.arc(coin.x, coin.y, coinSize, 0, Math.PI * 2)
-      this.ctx.fill()
-      
-      // Bright outline for visibility
-      this.ctx.strokeStyle = '#FFFF00'
-      this.ctx.lineWidth = 2
-      this.ctx.stroke()
-      
-      // Inner sparkle
-      this.ctx.fillStyle = '#FFFFFF'
-      this.ctx.beginPath()
-      this.ctx.arc(coin.x - coinSize * 0.3, coin.y - coinSize * 0.3, coinSize * 0.2, 0, Math.PI * 2)
-      this.ctx.fill()
-    }
-    
-    drawVirus(virus) {
-      // Enhanced virus rendering matching 2nd image - green spiky circles
-      const virusRadius = virus.radius || 50
-      const spikes = 12
-      
-      // Main virus body - bright green
-      this.ctx.fillStyle = '#00FF00'
-      this.ctx.beginPath()
-      
-      // Draw spiky outline
-      for (let i = 0; i < spikes; i++) {
-        const angle = (i / spikes) * Math.PI * 2
-        const isSpike = i % 2 === 0
-        const radius = isSpike ? virusRadius * 1.3 : virusRadius * 0.8
-        
-        const x = virus.x + Math.cos(angle) * radius
-        const y = virus.y + Math.sin(angle) * radius
-        
-        if (i === 0) {
-          this.ctx.moveTo(x, y)
+
+      if (player.botType) {
+        if (player.botType === 'aggressive') {
+          this.ctx.strokeStyle = '#ff4444'
+          this.ctx.lineWidth = 4
+          this.ctx.setLineDash([8, 4])
+        } else if (player.botType === 'defensive') {
+          this.ctx.strokeStyle = '#44ff44'
+          this.ctx.lineWidth = 5
+          this.ctx.setLineDash([])
+        } else if (player.botType === 'fast') {
+          this.ctx.strokeStyle = '#ffff44'
+          this.ctx.lineWidth = 3
+          this.ctx.setLineDash([4, 2, 4, 2])
         } else {
-          this.ctx.lineTo(x, y)
+          this.ctx.strokeStyle = '#4444ff'
+          this.ctx.lineWidth = 3
+          this.ctx.setLineDash([6, 3])
+        }
+
+        if (player.behavior === 'hunting_player') {
+          this.ctx.shadowColor = '#ff0000'
+          this.ctx.shadowBlur = 8
+        } else if (player.behavior === 'fleeing') {
+          this.ctx.shadowColor = '#ffff00'
+          this.ctx.shadowBlur = 6
+        } else if (player.behavior === 'hunting_enemy') {
+          this.ctx.shadowColor = '#ff8800'
+          this.ctx.shadowBlur = 5
+        }
+
+        this.ctx.stroke()
+        this.ctx.shadowBlur = 0
+        this.ctx.setLineDash([])
+      } else {
+        this.ctx.strokeStyle = '#ffffff'
+        this.ctx.lineWidth = 3
+        this.ctx.stroke()
+      }
+
+      if (player.spawnProtection) {
+        this.ctx.beginPath()
+        this.ctx.arc(player.x, player.y, radius + 8, 0, Math.PI * 2)
+        this.ctx.strokeStyle = '#3B82F6'
+        this.ctx.lineWidth = 4
+        this.ctx.setLineDash([10, 5])
+        this.ctx.stroke()
+        this.ctx.setLineDash([])
+
+        const time = Date.now() / 1000
+        const pulseIntensity = Math.sin(time * 4) * 0.3 + 0.7
+        this.ctx.globalAlpha = pulseIntensity
+
+        this.ctx.beginPath()
+        this.ctx.arc(player.x, player.y, radius + 6, 0, Math.PI * 2)
+        this.ctx.strokeStyle = '#60A5FA'
+        this.ctx.lineWidth = 2
+        this.ctx.stroke()
+
+        this.ctx.globalAlpha = 1.0
+      }
+
+      const isMainPlayer = isCurrentPlayer || (this.expectedSessionId && player.sessionId === this.expectedSessionId)
+      if (this.gameStates && this.gameStates.isCashingOut && this.gameStates.cashOutProgress > 0 && isMainPlayer) {
+        const ringRadius = radius + 8
+        const progressAngle = (this.gameStates.cashOutProgress / 100) * Math.PI * 2
+
+        this.ctx.beginPath()
+        this.ctx.arc(player.x, player.y, ringRadius, 0, Math.PI * 2)
+        this.ctx.strokeStyle = 'rgba(34, 197, 94, 0.3)'
+        this.ctx.lineWidth = 6
+        this.ctx.stroke()
+
+        this.ctx.beginPath()
+        this.ctx.arc(player.x, player.y, ringRadius, -Math.PI / 2, -Math.PI / 2 + progressAngle)
+        this.ctx.strokeStyle = '#00ff00'
+        this.ctx.lineWidth = 6
+        this.ctx.lineCap = 'round'
+        this.ctx.stroke()
+
+        this.ctx.beginPath()
+        this.ctx.arc(player.x, player.y, ringRadius + 2, -Math.PI / 2, -Math.PI / 2 + progressAngle)
+        this.ctx.strokeStyle = 'rgba(0, 255, 0, 0.6)'
+        this.ctx.lineWidth = 3
+        this.ctx.lineCap = 'round'
+        this.ctx.stroke()
+
+        const time = Date.now() / 1000
+        const pulseIntensity = Math.sin(time * 6) * 0.3 + 0.8
+        this.ctx.globalAlpha = pulseIntensity
+
+        this.ctx.beginPath()
+        this.ctx.arc(player.x, player.y, ringRadius - 2, -Math.PI / 2, -Math.PI / 2 + progressAngle)
+        this.ctx.strokeStyle = '#66ff66'
+        this.ctx.lineWidth = 3
+        this.ctx.lineCap = 'round'
+        this.ctx.stroke()
+
+        this.ctx.globalAlpha = 1.0
+      }
+
+      this.ctx.fillStyle = '#ffffff'
+      this.ctx.font = 'bold 14px Arial'
+      this.ctx.textAlign = 'center'
+
+      let displayName = player.name || 'Player'
+      if (player.botType) {
+        const botEmojis = {
+          aggressive: '⚔️',
+          defensive: '🛡️',
+          fast: '⚡',
+          balanced: '⚖️'
+        }
+        displayName = `${botEmojis[player.botType] || ''} ${displayName}`.trim()
+      }
+
+      this.ctx.fillText(displayName, player.x, player.y - radius - 15)
+
+      const eyeRadius = Math.max(2, radius * 0.12)
+      const eyeOffset = radius * 0.35
+
+      this.ctx.beginPath()
+      this.ctx.arc(player.x - eyeOffset, player.y - eyeOffset * 0.3, eyeRadius, 0, Math.PI * 2)
+      this.ctx.fillStyle = '#000000'
+      this.ctx.fill()
+
+      this.ctx.beginPath()
+      this.ctx.arc(player.x + eyeOffset, player.y - eyeOffset * 0.3, eyeRadius, 0, Math.PI * 2)
+      this.ctx.fillStyle = '#000000'
+      this.ctx.fill()
+
+      if (player.botType && player.behavior && player.behavior !== 'exploring') {
+        this.ctx.fillStyle = '#ffff88'
+        this.ctx.font = '10px Arial'
+        this.ctx.textAlign = 'center'
+
+        const behaviorText = {
+          hunting_player: '🎯 HUNTING YOU!',
+          fleeing: '💨 FLEEING',
+          hunting_enemy: '🔍 HUNTING',
+          hunting_coins: '🪙 COIN HUNT'
+        }[player.behavior] || ''
+
+        if (behaviorText) {
+          this.ctx.fillText(behaviorText, player.x, player.y - radius - 35)
         }
       }
-      
-      this.ctx.closePath()
-      this.ctx.fill()
-      
-      // Virus border - darker green
-      this.ctx.strokeStyle = '#00AA00'
-      this.ctx.lineWidth = 4
-      this.ctx.stroke()
-      
-      // Inner pattern - darker core
-      this.ctx.fillStyle = '#008800'
+    }
+
+    drawCoin(coin) {
+      const radius = coin.radius || 8
+
       this.ctx.beginPath()
-      this.ctx.arc(virus.x, virus.y, virusRadius * 0.5, 0, Math.PI * 2)
+      this.ctx.arc(coin.x, coin.y, radius, 0, Math.PI * 2)
+      this.ctx.fillStyle = coin.color || '#FFD700'
       this.ctx.fill()
-      
-      // Virus "eyes" or spots
-      this.ctx.fillStyle = '#004400'
-      for (let i = 0; i < 3; i++) {
-        const spotAngle = (i / 3) * Math.PI * 2
-        const spotX = virus.x + Math.cos(spotAngle) * virusRadius * 0.25
-        const spotY = virus.y + Math.sin(spotAngle) * virusRadius * 0.25
-        
-        this.ctx.beginPath()
-        this.ctx.arc(spotX, spotY, virusRadius * 0.08, 0, Math.PI * 2)
-        this.ctx.fill()
+
+      this.ctx.strokeStyle = '#FFB000'
+      this.ctx.lineWidth = 2
+      this.ctx.stroke()
+
+      this.ctx.fillStyle = '#000000'
+      this.ctx.font = 'bold 12px Arial'
+      this.ctx.textAlign = 'center'
+      this.ctx.fillText('$', coin.x, coin.y + 4)
+    }
+
+    drawVirus(virus) {
+      virus.currentRotation = isNaN(virus.currentRotation) ? 0 : virus.currentRotation
+      virus.rotationSpeed = isNaN(virus.rotationSpeed) ? 0.5 : virus.rotationSpeed
+      virus.pulsePhase = isNaN(virus.pulsePhase) ? 0 : virus.pulsePhase
+      virus.pulseSpeed = isNaN(virus.pulseSpeed) ? 0.02 : virus.pulseSpeed
+      virus.spikeWavePhase = isNaN(virus.spikeWavePhase) ? 0 : virus.spikeWavePhase
+      virus.spikeWaveSpeed = isNaN(virus.spikeWaveSpeed) ? 0.05 : virus.spikeWaveSpeed
+      virus.colorShift = isNaN(virus.colorShift) ? 0 : virus.colorShift
+      virus.glowIntensity = isNaN(virus.glowIntensity) ? 0.5 : virus.glowIntensity
+      virus.radius = isNaN(virus.radius) ? 30 : virus.radius
+      virus.spikes = isNaN(virus.spikes) ? 12 : virus.spikes
+
+      virus.currentRotation += virus.rotationSpeed
+      virus.pulsePhase += virus.pulseSpeed
+      virus.spikeWavePhase += virus.spikeWaveSpeed
+
+      const pulseScale = 1 + Math.sin(virus.pulsePhase) * 0.1
+      const glowPulse = 0.5 + Math.sin(virus.pulsePhase * 1.5) * 0.3
+
+      this.ctx.save()
+      this.ctx.translate(virus.x, virus.y)
+      this.ctx.rotate((virus.currentRotation * Math.PI) / 180)
+      this.ctx.scale(pulseScale, pulseScale)
+
+      const gradient = this.ctx.createRadialGradient(0, 0, 0, 0, 0, virus.radius + 20)
+      const safeColorShift = isNaN(virus.colorShift) ? 0 : virus.colorShift
+
+      gradient.addColorStop(0, `hsl(120, 100%, ${50 + safeColorShift}%)`)
+      gradient.addColorStop(0.6, '#00FF41')
+      gradient.addColorStop(1, '#00AA00')
+
+      this.ctx.shadowColor = '#00FF41'
+      const safeGlowIntensity = isNaN(virus.glowIntensity) ? 0.5 : virus.glowIntensity
+      this.ctx.shadowBlur = 15 * safeGlowIntensity * glowPulse
+      this.ctx.shadowOffsetX = 0
+      this.ctx.shadowOffsetY = 0
+
+      this.ctx.beginPath()
+      for (let i = 0; i < virus.spikes; i++) {
+        const baseAngle = (i / virus.spikes) * Math.PI * 2
+        const spikeWave = Math.sin(virus.spikeWavePhase + i * 0.5) * 3
+        const spikeLength = virus.radius + 12 + spikeWave
+        const innerRadius = virus.radius - 3
+
+        const outerX = Math.cos(baseAngle) * spikeLength
+        const outerY = Math.sin(baseAngle) * spikeLength
+
+        const nextAngle = ((i + 0.5) / virus.spikes) * Math.PI * 2
+        const innerX = Math.cos(nextAngle) * innerRadius
+        const innerY = Math.sin(nextAngle) * innerRadius
+
+        if (i === 0) {
+          this.ctx.moveTo(outerX, outerY)
+        } else {
+          this.ctx.lineTo(outerX, outerY)
+        }
+        this.ctx.lineTo(innerX, innerY)
       }
+      this.ctx.closePath()
+
+      this.ctx.fillStyle = gradient
+      this.ctx.fill()
+
+      this.ctx.strokeStyle = `rgba(0, 170, 0, ${0.8 + glowPulse * 0.2})`
+      this.ctx.lineWidth = 2 + Math.sin(virus.pulsePhase * 2) * 0.5
+      this.ctx.stroke()
+
+      this.ctx.shadowBlur = 0
+
+      const coreRadius = virus.radius - 15
+      const coreGradient = this.ctx.createRadialGradient(0, 0, 0, 0, 0, coreRadius)
+      coreGradient.addColorStop(0, `rgba(0, 255, 65, ${0.8 + glowPulse * 0.2})`)
+      coreGradient.addColorStop(1, '#005500')
+
+      this.ctx.beginPath()
+      this.ctx.arc(0, 0, coreRadius, 0, Math.PI * 2)
+      this.ctx.fillStyle = coreGradient
+      this.ctx.fill()
+
+      const eyeRadius = Math.max(4, virus.radius * 0.1)
+      const eyeOffset = virus.radius * 0.35
+
+      this.ctx.fillStyle = 'rgba(0, 80, 0, 0.9)'
+      this.ctx.beginPath()
+      this.ctx.arc(-eyeOffset, -eyeOffset * 0.2, eyeRadius, 0, Math.PI * 2)
+      this.ctx.arc(eyeOffset, -eyeOffset * 0.2, eyeRadius, 0, Math.PI * 2)
+      this.ctx.fill()
+
+      this.ctx.fillStyle = 'rgba(0, 255, 65, 0.5)'
+      this.ctx.beginPath()
+      this.ctx.arc(0, eyeOffset * 0.3, eyeRadius, 0, Math.PI * 2)
+      this.ctx.fill()
+
+      this.ctx.restore()
     }
   }
 


### PR DESCRIPTION
## Summary
- synchronize arena cash-out state with the canvas engine so HUD progress rings match the local Agar.io mode
- port the Agar.io grid, circular boundary, and rendering logic for players, coins, and viruses into the arena engine to mirror the local layout

## Testing
- npm run lint *(fails: existing lint errors in unrelated files such as app/agario/page.js and legacy demo pages)*

------
https://chatgpt.com/codex/tasks/task_e_68d376a923b88330ad8ec1d8c0f96d0e