### PR TITLE
Prevent duplicate arena sessions for authenticated players

### DIFF
--- a/colyseus-index.js
+++ b/colyseus-index.js
@@ -106,10 +106,58 @@ class ArenaRoom extends Room {
   }
 
   onJoin(client, options = {}) {
+    const privyUserId = options.privyUserId || `anonymous_${Date.now()}`;
     const playerName = options.playerName || `Player_${Math.random().toString(36).substring(7)}`;
-    
-    console.log(`👋 Player joined: ${playerName} (${client.sessionId})`);
-    
+
+    console.log(`👋 Player attempting to join: ${playerName} (${client.sessionId}) - privyUserId: ${privyUserId}`);
+
+    const duplicateSessions = [];
+
+    this.state.players.forEach((existingPlayer, existingSessionId) => {
+      if (existingSessionId === client.sessionId) {
+        return;
+      }
+
+      let isDuplicate = false;
+
+      if (!privyUserId.startsWith('anonymous_')) {
+        const existingClient = this.clients.find((c) => c.sessionId === existingSessionId);
+        if (existingClient && existingClient.userData && existingClient.userData.privyUserId === privyUserId) {
+          isDuplicate = true;
+          console.log(`⚠️ DUPLICATE by privyUserId: ${privyUserId} (existing: ${existingSessionId}, new: ${client.sessionId})`);
+        }
+      }
+
+      if (!isDuplicate && existingPlayer.name === playerName) {
+        isDuplicate = true;
+        console.log(`⚠️ DUPLICATE by playerName: ${playerName} (existing: ${existingSessionId}, new: ${client.sessionId})`);
+      }
+
+      if (isDuplicate) {
+        duplicateSessions.push(existingSessionId);
+      }
+    });
+
+    if (duplicateSessions.length > 0) {
+      console.log(`🧹 Removing ${duplicateSessions.length} duplicate player(s) to prevent confusion`);
+      duplicateSessions.forEach((sessionId) => {
+        console.log(`🧹 Removing duplicate player: ${sessionId}`);
+        this.state.players.delete(sessionId);
+
+        const oldClient = this.clients.find((c) => c.sessionId === sessionId);
+        if (oldClient) {
+          console.log(`🔌 Disconnecting old client: ${sessionId}`);
+          try {
+            oldClient.leave(1000, 'Duplicate connection detected');
+          } catch (error) {
+            console.log('⚠️ Error disconnecting old client:', error);
+          }
+        }
+      });
+    } else {
+      console.log(`✅ No duplicates found for ${playerName} - proceeding with join`);
+    }
+
     // Create new player
     const player = new Player();
     player.name = playerName;
@@ -119,10 +167,16 @@ class ArenaRoom extends Room {
     player.radius = 20;
     player.color = this.generatePlayerColor();
     player.alive = true;
-    
+
     this.state.players.set(client.sessionId, player);
-    
-    console.log(`✅ Player spawned: ${playerName}`);
+
+    client.userData = {
+      privyUserId,
+      playerName,
+      lastInputTime: Date.now()
+    };
+
+    console.log(`✅ Player spawned: ${playerName} - No duplicates!`);
   }
 
   onLeave(client) {

--- a/colyseus-server-minimal/index.js
+++ b/colyseus-server-minimal/index.js
@@ -106,10 +106,58 @@ class ArenaRoom extends Room {
   }
 
   onJoin(client, options = {}) {
+    const privyUserId = options.privyUserId || `anonymous_${Date.now()}`;
     const playerName = options.playerName || `Player_${Math.random().toString(36).substring(7)}`;
-    
-    console.log(`👋 Player joined: ${playerName} (${client.sessionId})`);
-    
+
+    console.log(`👋 Player attempting to join: ${playerName} (${client.sessionId}) - privyUserId: ${privyUserId}`);
+
+    const duplicateSessions = [];
+
+    this.state.players.forEach((existingPlayer, existingSessionId) => {
+      if (existingSessionId === client.sessionId) {
+        return;
+      }
+
+      let isDuplicate = false;
+
+      if (!privyUserId.startsWith('anonymous_')) {
+        const existingClient = this.clients.find((c) => c.sessionId === existingSessionId);
+        if (existingClient && existingClient.userData && existingClient.userData.privyUserId === privyUserId) {
+          isDuplicate = true;
+          console.log(`⚠️ DUPLICATE by privyUserId: ${privyUserId} (existing: ${existingSessionId}, new: ${client.sessionId})`);
+        }
+      }
+
+      if (!isDuplicate && existingPlayer.name === playerName) {
+        isDuplicate = true;
+        console.log(`⚠️ DUPLICATE by playerName: ${playerName} (existing: ${existingSessionId}, new: ${client.sessionId})`);
+      }
+
+      if (isDuplicate) {
+        duplicateSessions.push(existingSessionId);
+      }
+    });
+
+    if (duplicateSessions.length > 0) {
+      console.log(`🧹 Removing ${duplicateSessions.length} duplicate player(s) to prevent confusion`);
+      duplicateSessions.forEach((sessionId) => {
+        console.log(`🧹 Removing duplicate player: ${sessionId}`);
+        this.state.players.delete(sessionId);
+
+        const oldClient = this.clients.find((c) => c.sessionId === sessionId);
+        if (oldClient) {
+          console.log(`🔌 Disconnecting old client: ${sessionId}`);
+          try {
+            oldClient.leave(1000, 'Duplicate connection detected');
+          } catch (error) {
+            console.log('⚠️ Error disconnecting old client:', error);
+          }
+        }
+      });
+    } else {
+      console.log(`✅ No duplicates found for ${playerName} - proceeding with join`);
+    }
+
     // Create new player
     const player = new Player();
     player.name = playerName;
@@ -119,10 +167,16 @@ class ArenaRoom extends Room {
     player.radius = 20;
     player.color = this.generatePlayerColor();
     player.alive = true;
-    
+
     this.state.players.set(client.sessionId, player);
-    
-    console.log(`✅ Player spawned: ${playerName}`);
+
+    client.userData = {
+      privyUserId,
+      playerName,
+      lastInputTime: Date.now()
+    };
+
+    console.log(`✅ Player spawned: ${playerName} - No duplicates!`);
   }
 
   onLeave(client) {

--- a/colyseus-server/src/ArenaRoom.ts
+++ b/colyseus-server/src/ArenaRoom.ts
@@ -85,9 +85,56 @@ export class ArenaRoom extends Room<GameState> {
   onJoin(client: Client, options: any = {}) {
     const privyUserId = options.privyUserId || `anonymous_${Date.now()}`;
     const playerName = options.playerName || `Player_${Math.random().toString(36).substring(7)}`;
-    
-    console.log(`👋 Player joined: ${playerName} (${client.sessionId})`);
-    
+
+    console.log(`👋 Player attempting to join: ${playerName} (${client.sessionId}) - privyUserId: ${privyUserId}`);
+
+    const duplicateSessions: string[] = [];
+
+    this.state.players.forEach((existingPlayer, existingSessionId) => {
+      if (existingSessionId === client.sessionId) {
+        return;
+      }
+
+      let isDuplicate = false;
+
+      if (!privyUserId.startsWith('anonymous_')) {
+        const existingClient = this.clients.find((c) => c.sessionId === existingSessionId);
+        if (existingClient && (existingClient as any).userData?.privyUserId === privyUserId) {
+          isDuplicate = true;
+          console.log(`⚠️ DUPLICATE by privyUserId: ${privyUserId} (existing: ${existingSessionId}, new: ${client.sessionId})`);
+        }
+      }
+
+      if (!isDuplicate && existingPlayer.name === playerName) {
+        isDuplicate = true;
+        console.log(`⚠️ DUPLICATE by playerName: ${playerName} (existing: ${existingSessionId}, new: ${client.sessionId})`);
+      }
+
+      if (isDuplicate) {
+        duplicateSessions.push(existingSessionId);
+      }
+    });
+
+    if (duplicateSessions.length > 0) {
+      console.log(`🧹 Removing ${duplicateSessions.length} duplicate player(s) to prevent confusion`);
+      duplicateSessions.forEach((sessionId) => {
+        console.log(`🧹 Removing duplicate player: ${sessionId}`);
+        this.state.players.delete(sessionId);
+
+        const oldClient = this.clients.find((c) => c.sessionId === sessionId);
+        if (oldClient) {
+          console.log(`🔌 Disconnecting old client: ${sessionId}`);
+          try {
+            oldClient.leave(1000, 'Duplicate connection detected');
+          } catch (error) {
+            console.log('⚠️ Error disconnecting old client:', error);
+          }
+        }
+      });
+    } else {
+      console.log(`✅ No duplicates found for ${playerName} - proceeding with join`);
+    }
+
     // Create new player
     const player = new Player();
     player.name = playerName;
@@ -101,18 +148,18 @@ export class ArenaRoom extends Room<GameState> {
     player.score = 0;
     player.lastSeq = 0;
     player.alive = true;
-    
+
     // Add player to game state
     this.state.players.set(client.sessionId, player);
-    
+
     // Store client metadata
     (client as any).userData = {
       privyUserId,
       playerName,
       lastInputTime: Date.now()
     };
-    
-    console.log(`✅ Player spawned at (${Math.round(player.x)}, ${Math.round(player.y)})`);
+
+    console.log(`✅ Player spawned at (${Math.round(player.x)}, ${Math.round(player.y)}) - No duplicates!`);
   }
 
   handleInput(client: Client, message: any) {

--- a/index-colyseus.js
+++ b/index-colyseus.js
@@ -106,10 +106,58 @@ class ArenaRoom extends Room {
   }
 
   onJoin(client, options = {}) {
+    const privyUserId = options.privyUserId || `anonymous_${Date.now()}`;
     const playerName = options.playerName || `Player_${Math.random().toString(36).substring(7)}`;
-    
-    console.log(`👋 Player joined: ${playerName} (${client.sessionId})`);
-    
+
+    console.log(`👋 Player attempting to join: ${playerName} (${client.sessionId}) - privyUserId: ${privyUserId}`);
+
+    const duplicateSessions = [];
+
+    this.state.players.forEach((existingPlayer, existingSessionId) => {
+      if (existingSessionId === client.sessionId) {
+        return;
+      }
+
+      let isDuplicate = false;
+
+      if (!privyUserId.startsWith('anonymous_')) {
+        const existingClient = this.clients.find((c) => c.sessionId === existingSessionId);
+        if (existingClient && existingClient.userData && existingClient.userData.privyUserId === privyUserId) {
+          isDuplicate = true;
+          console.log(`⚠️ DUPLICATE by privyUserId: ${privyUserId} (existing: ${existingSessionId}, new: ${client.sessionId})`);
+        }
+      }
+
+      if (!isDuplicate && existingPlayer.name === playerName) {
+        isDuplicate = true;
+        console.log(`⚠️ DUPLICATE by playerName: ${playerName} (existing: ${existingSessionId}, new: ${client.sessionId})`);
+      }
+
+      if (isDuplicate) {
+        duplicateSessions.push(existingSessionId);
+      }
+    });
+
+    if (duplicateSessions.length > 0) {
+      console.log(`🧹 Removing ${duplicateSessions.length} duplicate player(s) to prevent confusion`);
+      duplicateSessions.forEach((sessionId) => {
+        console.log(`🧹 Removing duplicate player: ${sessionId}`);
+        this.state.players.delete(sessionId);
+
+        const oldClient = this.clients.find((c) => c.sessionId === sessionId);
+        if (oldClient) {
+          console.log(`🔌 Disconnecting old client: ${sessionId}`);
+          try {
+            oldClient.leave(1000, 'Duplicate connection detected');
+          } catch (error) {
+            console.log('⚠️ Error disconnecting old client:', error);
+          }
+        }
+      });
+    } else {
+      console.log(`✅ No duplicates found for ${playerName} - proceeding with join`);
+    }
+
     // Create new player
     const player = new Player();
     player.name = playerName;
@@ -119,10 +167,16 @@ class ArenaRoom extends Room {
     player.radius = 20;
     player.color = this.generatePlayerColor();
     player.alive = true;
-    
+
     this.state.players.set(client.sessionId, player);
-    
-    console.log(`✅ Player spawned: ${playerName}`);
+
+    client.userData = {
+      privyUserId,
+      playerName,
+      lastInputTime: Date.now()
+    };
+
+    console.log(`✅ Player spawned: ${playerName} - No duplicates!`);
   }
 
   onLeave(client) {

--- a/server/src/rooms/ArenaRoom.ts
+++ b/server/src/rooms/ArenaRoom.ts
@@ -85,9 +85,59 @@ export class ArenaRoom extends Room<GameState> {
   onJoin(client: Client, options: any = {}) {
     const privyUserId = options.privyUserId || `anonymous_${Date.now()}`;
     const playerName = options.playerName || `Player_${Math.random().toString(36).substring(7)}`;
-    
-    console.log(`👋 Player joined: ${playerName} (${client.sessionId})`);
-    
+
+    console.log(`👋 Player attempting to join: ${playerName} (${client.sessionId}) - privyUserId: ${privyUserId}`);
+
+    // ROBUST DEDUPLICATION: Check existing players in game state directly
+    const duplicateSessions: string[] = [];
+
+    this.state.players.forEach((existingPlayer, existingSessionId) => {
+      if (existingSessionId === client.sessionId) {
+        return;
+      }
+
+      let isDuplicate = false;
+
+      // Method 1: Check by privyUserId for authenticated users
+      if (!privyUserId.startsWith('anonymous_')) {
+        const existingClient = this.clients.find((c) => c.sessionId === existingSessionId);
+        if (existingClient && (existingClient as any).userData?.privyUserId === privyUserId) {
+          isDuplicate = true;
+          console.log(`⚠️ DUPLICATE by privyUserId: ${privyUserId} (existing: ${existingSessionId}, new: ${client.sessionId})`);
+        }
+      }
+
+      // Method 2: Check by playerName (always, as fallback)
+      if (!isDuplicate && existingPlayer.name === playerName) {
+        isDuplicate = true;
+        console.log(`⚠️ DUPLICATE by playerName: ${playerName} (existing: ${existingSessionId}, new: ${client.sessionId})`);
+      }
+
+      if (isDuplicate) {
+        duplicateSessions.push(existingSessionId);
+      }
+    });
+
+    if (duplicateSessions.length > 0) {
+      console.log(`🧹 Removing ${duplicateSessions.length} duplicate player(s) to prevent confusion`);
+      duplicateSessions.forEach((sessionId) => {
+        console.log(`🧹 Removing duplicate player: ${sessionId}`);
+        this.state.players.delete(sessionId);
+
+        const oldClient = this.clients.find((c) => c.sessionId === sessionId);
+        if (oldClient) {
+          console.log(`🔌 Disconnecting old client: ${sessionId}`);
+          try {
+            oldClient.leave(1000, 'Duplicate connection detected');
+          } catch (error) {
+            console.log('⚠️ Error disconnecting old client:', error);
+          }
+        }
+      });
+    } else {
+      console.log(`✅ No duplicates found for ${playerName} - proceeding with join`);
+    }
+
     // Create new player
     const player = new Player();
     player.name = playerName;
@@ -101,18 +151,18 @@ export class ArenaRoom extends Room<GameState> {
     player.score = 0;
     player.lastSeq = 0;
     player.alive = true;
-    
+
     // Add player to game state
     this.state.players.set(client.sessionId, player);
-    
+
     // Store client metadata
     (client as any).userData = {
       privyUserId,
       playerName,
       lastInputTime: Date.now()
     };
-    
-    console.log(`✅ Player spawned at (${Math.round(player.x)}, ${Math.round(player.y)})`);
+
+    console.log(`✅ Player spawned at (${Math.round(player.x)}, ${Math.round(player.y)}) - No duplicates!`);
   }
 
   handleInput(client: Client, message: any) {


### PR DESCRIPTION
## Summary
- add Privy-aware duplicate session detection in every arena room implementation so an authenticated player can only own one entity
- disconnect stale sessions and update client metadata before spawning to keep camera logic stable

## Testing
- npm run lint *(fails: repository already has lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d37f15adb48330b75434dded1c59fe