### PR TITLE
Use safe spawn positions for players

### DIFF
--- a/server/src/rooms/ArenaRoom.ts
+++ b/server/src/rooms/ArenaRoom.ts
@@ -91,8 +91,9 @@ export class ArenaRoom extends Room<GameState> {
     // Create new player
     const player = new Player();
     player.name = playerName;
-    player.x = Math.random() * this.worldSize;
-    player.y = Math.random() * this.worldSize;
+    const spawnPosition = this.generateSafeSpawnPosition();
+    player.x = spawnPosition.x;
+    player.y = spawnPosition.y;
     player.vx = 0;
     player.vy = 0;
     player.mass = 25;
@@ -250,8 +251,9 @@ export class ArenaRoom extends Room<GameState> {
   }
 
   respawnPlayer(player: Player) {
-    player.x = Math.random() * this.worldSize;
-    player.y = Math.random() * this.worldSize;
+    const spawnPosition = this.generateSafeSpawnPosition();
+    player.x = spawnPosition.x;
+    player.y = spawnPosition.y;
     player.vx = 0;
     player.vy = 0;
     player.mass = 25;


### PR DESCRIPTION
## Summary
- spawn new players via generateSafeSpawnPosition so they enter inside the safe radius
- reuse the safe spawn helper when respawning to keep revived players in bounds
- confirmed other respawn flows call respawnPlayer, so all player spawns stay within the 1800px radius

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d90703c40c8330a54fcc2725947a6c