### PR TITLE
Prevent double applying movement in multiplayer update loop

### DIFF
--- a/app/agario/page.js
+++ b/app/agario/page.js
@@ -2130,14 +2130,18 @@ const AgarIOGame = () => {
       const deltaTime = (now - this.lastUpdate) / 1000
       this.lastUpdate = now
 
-      // Always update player movement (for client-side prediction)
-      this.updatePlayer(deltaTime)
-      
+      const hasAuthoritativeState = window.isMultiplayer && this.serverState
+
+      // Only update local player movement when we don't have server authority
+      if (!hasAuthoritativeState) {
+        this.updatePlayer(deltaTime)
+      }
+
       // Always update camera
       this.updateCamera()
-      
+
       // Skip local AI and collision detection in multiplayer mode
-      if (window.isMultiplayer && this.serverState) {
+      if (hasAuthoritativeState) {
         console.log('🌐 Multiplayer mode: Using server-authoritative state')
         return // Server handles all game logic
       }


### PR DESCRIPTION
## Summary
- compute a reusable hasAuthoritativeState flag in the GameEngine update loop
- avoid local movement updates when server state is authoritative while keeping camera updates active

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9143e1bd88330bbb3bff1f4be0359