### PR TITLE
Ensure minimap overlay stays solid black

### DIFF
--- a/app/arena/page.js
+++ b/app/arena/page.js
@@ -2269,8 +2269,7 @@ const MultiplayerArena = () => {
               bottom: '0',
               borderRadius: '50%',
               border: '3px solid rgba(0, 255, 0, 0.8)',
-              background: 'conic-gradient(from 0deg, transparent 0%, rgba(0, 255, 0, 0.1) 10%, transparent 20%, rgba(0, 255, 0, 0.1) 30%, transparent 40%, rgba(0, 255, 0, 0.1) 50%, transparent 60%, rgba(0, 255, 0, 0.1) 70%, transparent 80%, rgba(0, 255, 0, 0.1) 90%, transparent 100%)',
-              animation: 'minimapRotate 20s linear infinite',
+              backgroundColor: '#000000',
               pointerEvents: 'none'
             }} />
           </div>


### PR DESCRIPTION
## Summary
- ensure the minimap overlay uses a solid black fill
- remove the rotating gradient animation so the overlay does not reintroduce the gradient

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d972464bd483309d33f293fcf8a180