### PR TITLE
Adjust virus collision minimum mass

### DIFF
--- a/server/build/rooms/ArenaRoom.js
+++ b/server/build/rooms/ArenaRoom.js
@@ -307,7 +307,7 @@ class ArenaRoom extends core_1.Room {
                 }
                 else {
                     // Player gets damaged
-                    player.mass = Math.max(50, player.mass * 0.8);
+                    player.mass = Math.max(25, player.mass * 0.8);
                     player.radius = Math.sqrt(player.mass / Math.PI) * 10;
                 }
             }

--- a/server/src/rooms/ArenaRoom.ts
+++ b/server/src/rooms/ArenaRoom.ts
@@ -212,7 +212,7 @@ export class ArenaRoom extends Room<GameState> {
           player.score += 10;
         } else {
           // Player gets damaged
-          player.mass = Math.max(50, player.mass * 0.8);
+          player.mass = Math.max(25, player.mass * 0.8);
           player.radius = Math.sqrt(player.mass / Math.PI) * 10;
         }
       }


### PR DESCRIPTION
## Summary
- lower the virus collision minimum mass threshold to 25 in ArenaRoom so spikes can reduce lighter players further
- rebuild the server output to capture the updated collision handling

## Testing
- npm run build (server)


------
https://chatgpt.com/codex/tasks/task_e_68d9fa54718c83308498391ec9a4dbde