### PR TITLE
Fix arena split connection guard to respect Colyseus isOpen state

### DIFF
--- a/app/arena/page.js
+++ b/app/arena/page.js
@@ -291,19 +291,21 @@ const MultiplayerArena = () => {
       console.log('🔗 WebSocket connection state before split:', {
         wsRef: !!wsRef.current,
         sessionId: wsRef.current?.sessionId,
-        connection: wsRef.current?.connection?.readyState,
-        transport: wsRef.current?.connection?.transport?.readyState
+        connectionIsOpen: wsRef.current?.connection?.isOpen,
+        transportIsOpen: wsRef.current?.connection?.transport?.isOpen,
+        transportReadyState: wsRef.current?.connection?.transport?.readyState
       })
-      
-      // Check if connection is still valid before sending (WebSocket.OPEN = 1)
-      if (!wsRef.current || !wsRef.current.connection || 
-          wsRef.current.connection.readyState !== 1) {
+
+      // Check if connection is still valid before sending
+      if (!wsRef.current || !wsRef.current.connection ||
+          !wsRef.current.connection.isOpen) {
         console.log('⚠️ Connection not ready for split - skipping split attempt')
         console.log('🔗 Connection details:', {
           hasWsRef: !!wsRef.current,
           hasConnection: !!wsRef.current?.connection,
-          readyState: wsRef.current?.connection?.readyState,
-          expectedState: 1 // WebSocket.OPEN
+          isOpen: wsRef.current?.connection?.isOpen,
+          transportIsOpen: wsRef.current?.connection?.transport?.isOpen,
+          transportReadyState: wsRef.current?.connection?.transport?.readyState
         })
         return
       }
@@ -322,8 +324,9 @@ const MultiplayerArena = () => {
         console.log('🔗 WebSocket connection state after error:', {
           wsRef: !!wsRef.current,
           sessionId: wsRef.current?.sessionId,
-          connection: wsRef.current?.connection?.readyState,
-          transport: wsRef.current?.connection?.transport?.readyState
+          connectionIsOpen: wsRef.current?.connection?.isOpen,
+          transportIsOpen: wsRef.current?.connection?.transport?.isOpen,
+          transportReadyState: wsRef.current?.connection?.transport?.readyState
         })
       }
     }


### PR DESCRIPTION
## Summary
- update the arena split handler to rely on connection.isOpen instead of the nonexistent readyState flag
- expand split debugging output with transport isOpen and readyState details for easier diagnosis

## Testing
- not run (authentication required to access arena gameplay locally)


------
https://chatgpt.com/codex/tasks/task_e_68da36976bcc833089c29663bf0f34fe