### PR TITLE
Adjust arena spawn protection duration to five seconds

### DIFF
--- a/app/arena/page.js
+++ b/app/arena/page.js
@@ -949,7 +949,7 @@ const MultiplayerArena = () => {
         targetX: 2000, // Updated center for left-side playable area (worldSize/4)
         targetY: 2000, // Updated center for top-side playable area (worldSize/4)
         spawnProtection: true,
-        spawnProtectionTime: 6000,
+        spawnProtectionTime: 5000,
         spawnProtectionStart: Date.now()
       }
       

--- a/src/rooms/ArenaRoom.ts
+++ b/src/rooms/ArenaRoom.ts
@@ -16,7 +16,7 @@ export class Player extends Schema {
   @type("boolean") alive: boolean = true;
   @type("boolean") spawnProtection: boolean = false; // Spawn protection status
   @type("number") spawnProtectionStart: number = 0; // When protection started
-  @type("number") spawnProtectionTime: number = 6000; // 6 seconds protection
+  @type("number") spawnProtectionTime: number = 5000; // 5 seconds protection
   
   // Server-side skin properties for multiplayer visibility
   @type("string") skinId: string = "default";
@@ -199,7 +199,7 @@ export class ArenaRoom extends Room<GameState> {
     // Initialize spawn protection
     player.spawnProtection = true;
     player.spawnProtectionStart = Date.now();
-    player.spawnProtectionTime = 6000; // 6 seconds protection
+    player.spawnProtectionTime = 5000; // 5 seconds protection
     
     console.log(`🎨 Player ${playerName} joined with skin: ${player.skinName} (${player.skinColor})`);
     
@@ -662,7 +662,7 @@ export class ArenaRoom extends Room<GameState> {
     // Enable spawn protection on respawn
     player.spawnProtection = true;
     player.spawnProtectionStart = Date.now();
-    player.spawnProtectionTime = 6000; // 6 seconds protection
+    player.spawnProtectionTime = 5000; // 5 seconds protection
     
     console.log(`🔄 Player respawned: ${player.name} at (${player.x.toFixed(1)}, ${player.y.toFixed(1)}) with spawn protection`);
   }


### PR DESCRIPTION
## Summary
- update the ArenaRoom player schema and spawn logic to use a five second spawn protection window
- align the client-side MultiplayerGameEngine default spawn protection duration with the server

## Testing
- not run (requires manual arena join smoke test)


------
https://chatgpt.com/codex/tasks/task_e_68da79088b748330983026998c568713