### PR TITLE
Guard global sendInputToServer when socket not connected

### DIFF
--- a/app/agario/page.js
+++ b/app/agario/page.js
@@ -3707,16 +3707,28 @@ const AgarIOGame = () => {
     console.log('🎮 MULTIPLAYER MODE UPDATE:')
     console.log('🎮 isMultiplayer changed to:', isMultiplayer)
     console.log('🎮 gameRef.current exists:', !!gameRef.current)
-    
-    // Update global state for existing game engine
-    window.sendInputToServer = sendInputToServer
+    console.log('🎮 wsConnection state:', wsConnection)
+
+    if (typeof window === 'undefined') {
+      return
+    }
+
     window.isMultiplayer = isMultiplayer
-    window.wsRef = wsRef
-    
+
+    if (wsConnection === 'connected') {
+      window.sendInputToServer = sendInputToServer
+      window.wsRef = wsRef
+      console.log('🎮 Global sendInputToServer assigned (connection active)')
+    } else {
+      window.sendInputToServer = undefined
+      window.wsRef = null
+      console.log('🎮 Global sendInputToServer cleared (connection inactive)')
+    }
+
     if (gameRef.current) {
       console.log('🎮 Updated existing game engine with multiplayer state')
     }
-  }, [isMultiplayer])
+  }, [isMultiplayer, sendInputToServer, wsConnection])
 
   // Debug: Monitor multiplayer state synchronization
   useEffect(() => {


### PR DESCRIPTION
## Summary
- update the multiplayer effect to log the websocket state and respect the latest sendInputToServer handler
- only expose window.sendInputToServer while the websocket connection is active and clear the global references otherwise

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcc5c0f24083309f5bf3a053127e8c