### PR TITLE
Ensure mobile server browser button opens modal

### DIFF
--- a/frontend/app/page.js
+++ b/frontend/app/page.js
@@ -4694,6 +4694,17 @@ export default function TurfLootTactical() {
     width: '100%'
   }
 
+  const serverBrowserModal = (
+    <ServerBrowserModal
+      isOpen={isServerBrowserOpen}
+      onClose={() => {
+        console.log('Closing server browser modal')
+        setIsServerBrowserOpen(false)
+      }}
+      onJoinLobby={handleJoinLobby}
+    />
+  )
+
   // Desktop Layout
   if (!isMobile) {
     return (
@@ -7265,14 +7276,7 @@ export default function TurfLootTactical() {
         `}</style>
 
         {/* Server Browser Modal */}
-        <ServerBrowserModal
-          isOpen={isServerBrowserOpen}
-          onClose={() => {
-            console.log('Closing server browser modal')
-            setIsServerBrowserOpen(false)
-          }}
-          onJoinLobby={handleJoinLobby}
-        />
+        {serverBrowserModal}
 
         {/* User Profile Modal */}
         {isProfileModalOpen && (
@@ -10424,7 +10428,8 @@ export default function TurfLootTactical() {
         }
       `}</style>
 
-      {/* Server Browser Modal instance removed - using the one in desktop view to avoid duplication */}
+      {/* Shared Server Browser Modal */}
+      {serverBrowserModal}
 
       {/* Mobile Orientation Modal */}
       {showOrientationModal && isMobile && (


### PR DESCRIPTION
## Summary
- create a shared ServerBrowserModal instance that both desktop and mobile views can render
- render the shared modal inside the mobile landing layout so tapping the button opens the server browser

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd1cb1629c833080c52c104cef7356