### PR TITLE
Add WebSocket readiness guard for split command

### DIFF
--- a/app/arena/page.js
+++ b/app/arena/page.js
@@ -232,6 +232,27 @@ const MultiplayerArena = () => {
     }
   }
 
+  const isSplitConnectionOpen = () => {
+    const openState =
+      typeof WebSocket !== 'undefined' && typeof WebSocket.OPEN === 'number'
+        ? WebSocket.OPEN
+        : 1
+
+    const readyState = wsRef.current?.connection?.readyState
+    const isOpen = readyState === openState
+
+    if (!isOpen) {
+      console.warn('⚠️ Split denied - WebSocket connection not open:', {
+        hasWsRef: !!wsRef.current,
+        hasConnection: !!wsRef.current?.connection,
+        readyState,
+        expectedOpenState: openState
+      })
+    }
+
+    return isOpen
+  }
+
   // Handle split functionality - ported from agario with improved error handling
   const handleSplit = (e) => {
     console.log('🎯 handleSplit called - checking initial conditions...')
@@ -340,7 +361,11 @@ const MultiplayerArena = () => {
         console.log('❌ Split failed - no valid Colyseus session')
         return
       }
-      
+
+      if (!isSplitConnectionOpen()) {
+        return
+      }
+
       // Send split message to server (server-authoritative approach)
       console.log('🚀 Sending split message to server')
       wsRef.current.send("split", { targetX, targetY })


### PR DESCRIPTION
## Summary
- add a helper that verifies the WebSocket connection is open before sending split commands
- reuse the helper inside the split handler to exit early and warn when the connection is closed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd5680dc4c83308117321ad4064fa6