### PR TITLE
Reset arena split owner movement target

### DIFF
--- a/src/rooms/ArenaRoom.ts
+++ b/src/rooms/ArenaRoom.ts
@@ -339,6 +339,12 @@ export class ArenaRoom extends Room<GameState> {
       player.mass = newMass;
       player.radius = Math.sqrt(player.mass) * 3;
       player.lastSplitTime = now;
+
+      // Reset movement targets and clear any residual momentum so the owner stays put
+      player.vx = player.x;
+      player.vy = player.y;
+      player.momentumX = 0;
+      player.momentumY = 0;
       
       console.log(`📊 Mass halved: ${originalMass} → ${newMass}`);
 


### PR DESCRIPTION
## Summary
- reset the splitting player's movement target and momentum so the main cell remains stationary after mass is halved

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68de377ca2948330aa13f2ac114b67b4