### PR TITLE
Remove arena respawns and display elimination modal

### DIFF
--- a/server/build/rooms/ArenaRoom.d.ts
+++ b/server/build/rooms/ArenaRoom.d.ts
@@ -73,7 +73,6 @@ export declare class ArenaRoom extends Room<GameState> {
     handleSplitMerging(currentTime: number): void;
     areSameOwner(player: Player, sessionId: string, otherPlayer: Player, otherSessionId: string): boolean;
     calculateRadius(mass: number): number;
-    respawnPlayer(player: Player): void;
     generateCoins(): void;
     generateViruses(): void;
     spawnCoin(): void;

--- a/server/src/rooms/ArenaRoom.ts
+++ b/server/src/rooms/ArenaRoom.ts
@@ -499,12 +499,52 @@ export class ArenaRoom extends Room<GameState> {
           otherPlayer.alive = false;
           console.log(`💀 ${player.name} eliminated ${otherPlayer.name}`);
 
-          // Respawn eliminated player after 3 seconds
-          setTimeout(() => {
-            if (this.state.players.has(otherSessionId)) {
-              this.respawnPlayer(otherPlayer);
+          if (otherPlayer.isSplitPiece) {
+            console.log(`🧩 Removing split piece ${otherSessionId} owned by ${otherPlayer.ownerSessionId}`);
+            this.state.players.delete(otherSessionId);
+            return;
+          }
+
+          const eliminatedBy = player.name;
+          const finalScore = otherPlayer.score;
+          const finalMass = otherPlayer.mass;
+
+          const eliminatedClient = this.clients.find((client) => client.sessionId === otherSessionId);
+          if (eliminatedClient) {
+            try {
+              eliminatedClient.send("gameOver", {
+                finalScore,
+                finalMass,
+                eliminatedBy
+              });
+            } catch (error) {
+              console.log(`⚠️ Failed to send gameOver to ${otherPlayer.name} (${otherSessionId}):`, error);
             }
-          }, 3000);
+          } else {
+            console.log(`⚠️ No active client found for eliminated player ${otherPlayer.name} (${otherSessionId})`);
+          }
+
+          this.state.players.delete(otherSessionId);
+
+          const splitPiecesToRemove: string[] = [];
+          this.state.players.forEach((candidate, candidateSessionId) => {
+            if (candidate.isSplitPiece && candidate.ownerSessionId === otherSessionId) {
+              splitPiecesToRemove.push(candidateSessionId);
+            }
+          });
+
+          splitPiecesToRemove.forEach((splitSessionId) => {
+            console.log(`🧹 Removing split piece ${splitSessionId} for eliminated player ${otherSessionId}`);
+            this.state.players.delete(splitSessionId);
+          });
+
+          if (eliminatedClient) {
+            try {
+              eliminatedClient.leave(1000, "Eliminated from arena");
+            } catch (error) {
+              console.log(`⚠️ Failed to disconnect eliminated player ${otherPlayer.name} (${otherSessionId}):`, error);
+            }
+          }
         }
       }
     });
@@ -652,26 +692,6 @@ export class ArenaRoom extends Room<GameState> {
 
   calculateRadius(mass: number) {
     return Math.sqrt(mass / Math.PI) * 10;
-  }
-
-  respawnPlayer(player: Player) {
-    player.mass = 25;
-    player.radius = this.calculateRadius(player.mass);
-    const spawnPosition = this.getNextSpawnPosition(player.radius);
-    player.x = spawnPosition.x;
-    player.y = spawnPosition.y;
-    player.vx = 0;
-    player.vy = 0;
-    player.alive = true;
-    player.isSplitPiece = false;
-    player.splitTime = 0;
-    player.targetX = spawnPosition.x;
-    player.targetY = spawnPosition.y;
-    player.momentumX = 0;
-    player.momentumY = 0;
-    player.noMergeUntil = 0;
-    player.lastSplitTime = 0;
-    console.log(`🔄 Player respawned: ${player.name}`);
   }
 
   generateCoins() {

--- a/src/rooms/ArenaRoom.ts
+++ b/src/rooms/ArenaRoom.ts
@@ -800,26 +800,6 @@ export class ArenaRoom extends Room<GameState> {
     });
   }
 
-  respawnPlayer(player: Player) {
-    // Generate respawn position within circular playable area
-    const spawnPosition = this.getNextSpawnPosition();
-    player.x = spawnPosition.x;
-    player.y = spawnPosition.y;
-    
-    player.vx = 0;
-    player.vy = 0;
-    player.mass = 25; // Updated to 25 to match user requirement
-    player.radius = Math.sqrt(player.mass) * 3; // Use proper formula: √25 * 3 = 15
-    player.alive = true;
-    
-    // Enable spawn protection on respawn
-    player.spawnProtection = true;
-    player.spawnProtectionStart = Date.now();
-    player.spawnProtectionTime = 4000; // 4 seconds protection
-    
-    console.log(`🔄 Player respawned: ${player.name} at (${player.x.toFixed(1)}, ${player.y.toFixed(1)}) with spawn protection`);
-  }
-
   generateCoins() {
     for (let i = 0; i < this.maxCoins; i++) {
       this.spawnCoin();


### PR DESCRIPTION
## Summary
- update the arena server logic to remove players permanently when eaten and notify the client with a `gameOver` payload
- wire the arena page to stop sending inputs, react to the new elimination payload, and render the game-over modal used in local mode
- keep the compiled Colyseus outputs in sync so every runtime stops respawning

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0a460e1108330a2ad32dbfff0a803