### PR TITLE
Fix equipped skin detection in popup

### DIFF
--- a/frontend/app/page.js
+++ b/frontend/app/page.js
@@ -3264,7 +3264,7 @@ export default function TurfLootTactical() {
       
       skinsGrid.innerHTML = filteredSkins.map(skin => {
         const rarityColor = rarityColors[skin.rarity]
-        const isEquipped = skin.id === selectedSkinData.id // Use the current selected skin instead of static currentSkin
+        const isEquipped = skin.id === currentSkin // Compare against mutable currentSkin to reflect latest selection
         const canAfford = currentCurrency >= skin.price
         
         return `


### PR DESCRIPTION
## Summary
- ensure the skin store popup uses the latest equipped skin selection by comparing against the mutable `currentSkin`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0bbc8ceac8330a9225d292936c0b5