### PR TITLE
Ensure game session tracking uses stable player identifiers

### DIFF
--- a/frontend/app/api/game-sessions/route.js
+++ b/frontend/app/api/game-sessions/route.js
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { MongoClient } from 'mongodb'
+import { randomUUID } from 'crypto'
 
 // MongoDB connection helper
 async function getDb() {
@@ -12,79 +13,94 @@ export async function POST(request) {
   try {
     const body = await request.json()
     const { action, session, roomId, lastActivity } = body
-    
+
     console.log(`🎮 Game session tracking: ${action}`, { roomId, session })
-    
+
     const { client, db } = await getDb()
     const gameSessions = db.collection('game_sessions')
-    
+
+    let resolvedUserId = null
+
     if (action === 'join') {
       // Player joining a room
       if (!session || !session.roomId) {
         return NextResponse.json({ error: 'Missing session data' }, { status: 400 })
       }
-      
+
+      resolvedUserId = typeof session.userId === 'string' && session.userId.trim()
+        ? session.userId.trim()
+        : (typeof body.userId === 'string' && body.userId.trim() ? body.userId.trim() : randomUUID())
+
       // Create or update session record
       const sessionDoc = {
         ...session,
-        userId: 'anonymous', // TODO: Add real Privy user ID when available
+        userId: resolvedUserId,
         joinedAt: new Date(session.joinedAt),
         lastActivity: new Date(session.lastActivity),
         status: 'active'
       }
-      
+
       // Upsert session (create if new, update if exists)
       await gameSessions.updateOne(
         { roomId: session.roomId, userId: sessionDoc.userId },
         { $set: sessionDoc },
         { upsert: true }
       )
-      
+
       console.log(`✅ Player session recorded for room ${session.roomId}`)
-      
+
     } else if (action === 'update') {
       // Player updating activity (heartbeat)
-      if (!roomId || !lastActivity) {
-        return NextResponse.json({ error: 'Missing roomId or lastActivity' }, { status: 400 })
+      const { userId } = body
+
+      if (!roomId || !lastActivity || !userId) {
+        return NextResponse.json({ error: 'Missing roomId, userId, or lastActivity' }, { status: 400 })
       }
-      
+
+      resolvedUserId = userId
+
       // Update last activity timestamp
-      await gameSessions.updateMany(
-        { roomId, status: 'active' },
-        { $set: { lastActivity: new Date(lastActivity) } }
+      await gameSessions.updateOne(
+        { roomId, userId },
+        { $set: { lastActivity: new Date(lastActivity), status: 'active' } }
       )
-      
+
       console.log(`🔄 Updated activity for room ${roomId}`)
-      
+
     } else if (action === 'leave') {
       // Player leaving a room
-      if (!roomId) {
-        return NextResponse.json({ error: 'Missing roomId' }, { status: 400 })
+      const { userId } = body
+
+      if (!roomId || !userId) {
+        return NextResponse.json({ error: 'Missing roomId or userId' }, { status: 400 })
       }
-      
+
+      resolvedUserId = userId
+
       // Mark session as inactive or remove it
-      await gameSessions.updateMany(
-        { roomId, status: 'active' },
+      await gameSessions.updateOne(
+        { roomId, userId, status: 'active' },
         { $set: { status: 'left', leftAt: new Date() } }
       )
-      
+
       console.log(`👋 Player left room ${roomId}`)
-      
+
     } else {
       return NextResponse.json({ error: 'Invalid action' }, { status: 400 })
     }
     
     await client.close()
     
-    return NextResponse.json({ 
-      success: true, 
+    return NextResponse.json({
+      success: true,
       action,
-      message: `Session ${action} completed successfully` 
+      message: `Session ${action} completed successfully`,
+      userId: resolvedUserId
     })
-    
+
   } catch (error) {
     console.error('❌ Error in game-sessions API:', error)
-    return NextResponse.json({ 
+    return NextResponse.json({
       error: 'Internal server error',
       message: error.message 
     }, { status: 500 })


### PR DESCRIPTION
## Summary
- update the game session API to persist unique user IDs per player and require them for updates and leaves
- generate or reuse a stable player identifier on the AgarIO client and send it with join/update/leave/session tracking payloads
- reuse the same identifier when establishing Colyseus connections so concurrent players are tracked separately

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0c016ba108330a2c70892fee7e346