### PR TITLE
Add Solana kit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@radix-ui/react-toggle": "^1.0.3",
     "@radix-ui/react-toggle-group": "^1.0.4",
     "@radix-ui/react-tooltip": "^1.0.7",
+    "@solana/kit": "^3.0.3",
     "@solana/wallet-adapter-backpack": "^0.1.14",
     "@solana/wallet-adapter-phantom": "^0.9.28",
     "@solana/wallet-adapter-solflare": "^0.6.32",


### PR DESCRIPTION
## Summary
- add `@solana/kit` to the Next.js frontend dependencies so Solana integrations can resolve the package

## Testing
- `yarn install` *(fails: registry.npmjs.org returns HTTP 403 through the required proxy, so the lockfile could not be regenerated in this environment)*
- `yarn build` *(fails: Next.js cannot reach Google Fonts in this environment and later reports existing module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e28774959c83308b3a470f76dd5a06