### PR TITLE
Center missions popup in arena mode

### DIFF
--- a/app/arena/page.js
+++ b/app/arena/page.js
@@ -2618,14 +2618,17 @@ const MultiplayerArena = () => {
           style={{
             position: 'fixed',
             top: isMobile ? 'calc(env(safe-area-inset-top, 0px) + 12px)' : '20px',
-            left: isMobile ? 'auto' : 'calc(env(safe-area-inset-left, 0px) + 20px)',
-            right: isMobile ? 'calc(env(safe-area-inset-right, 0px) + 12px)' : 'auto',
+            left: '50%',
+            transform: 'translateX(-50%)',
             zIndex: 1200,
-            width: 'auto',
+            width: '100%',
+            maxWidth: '100%',
             display: 'flex',
-            justifyContent: 'flex-start',
+            justifyContent: 'center',
             alignItems: 'flex-start',
-            pointerEvents: 'none'
+            pointerEvents: 'none',
+            paddingLeft: isMobile ? 'calc(env(safe-area-inset-left, 0px) + 12px)' : '0',
+            paddingRight: isMobile ? 'calc(env(safe-area-inset-right, 0px) + 12px)' : '0'
           }}
         >
           {missionPopupCondensed ? (


### PR DESCRIPTION
## Summary
- reposition the mission popup container so it appears centered at the top of the arena view
- ensure mobile safe-area padding is preserved while keeping mission cards interactive

## Testing
- npm run dev (fails: NEXT_PUBLIC_PRIVY_APP_ID is required)


------
https://chatgpt.com/codex/tasks/task_e_68e31f612784833093f624485d36dd58