### PR TITLE
Keep mission completion badge visible and sync coins

### DIFF
--- a/frontend/app/page.js
+++ b/frontend/app/page.js
@@ -1416,6 +1416,37 @@ export default function TurfLootTactical() {
       }
     }
   }, [currency, isAuthenticated, user])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    const handleExternalCurrencyUpdate = (event) => {
+      const detail = event?.detail
+      if (!detail) {
+        return
+      }
+
+      const rawValue = typeof detail.currency === 'number'
+        ? detail.currency
+        : parseInt(detail.currency, 10)
+
+      if (!Number.isFinite(rawValue)) {
+        return
+      }
+
+      const sanitizedValue = Math.max(0, Math.floor(rawValue))
+
+      setCurrency(prev => (prev === sanitizedValue ? prev : sanitizedValue))
+    }
+
+    window.addEventListener('turfloot:currencyUpdated', handleExternalCurrencyUpdate)
+
+    return () => {
+      window.removeEventListener('turfloot:currencyUpdated', handleExternalCurrencyUpdate)
+    }
+  }, [])
   
   // Selected skin system for cross-component synchronization
   const [selectedSkin, setSelectedSkin] = useState({


### PR DESCRIPTION
## Summary
- keep the mission UI visible after completion by showing a condensed badge with a green checkmark and reward details
- persist mission currency updates to the correct localStorage key and emit an event so other views (like the landing page) receive new coin totals
- listen for the shared currency update event on the landing page so the nav bar and skin store reflect mission rewards immediately

## Testing
- npm run dev *(fails: missing @solana-program/memo due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e338446554833090ca1ac91f0d2cb0