### PR TITLE
Update server browser room details

### DIFF
--- a/app/api/servers-proxy/route.js
+++ b/app/api/servers-proxy/route.js
@@ -13,7 +13,7 @@ export async function GET() {
         {
           id: 'global-turfloot-arena', // Use original working room identifier
           roomType: 'arena',
-          name: 'TurfLoot Arena 24/7',
+          name: 'Turfloot $1 Room - Australia',
           region: 'Australia',
           regionId: 'au-syd',
           endpoint: colyseusEndpoint,


### PR DESCRIPTION
## Summary
- increment server browser occupancy locally when players join or create rooms to keep player counts fresh
- fall back to refreshing server data when joins fail and reuse the new join handler in all relevant buttons
- rename the persistent Colyseus room to "Turfloot $1 Room - Australia"

## Testing
- npm run dev *(fails: missing @solana-program/memo while loading fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e33d2517d08330bea3407e5c4d4858