### PR TITLE
Fix Solana deposit flow to show funding options

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -2544,20 +2544,19 @@ export default function TurfLootTactical() {
         return
       }
 
-      const desiredAmount = '0.1'
-      console.log('✅ fundWallet is available, opening Privy funding modal for amount:', desiredAmount)
-
-      await fundWallet({
+      const fundingRequest = {
         address: solanaWallet.address,
         options: {
           chain: 'solana:mainnet',
-          asset: 'native-currency',
-          amount: desiredAmount,
-          defaultFundingMethod: 'exchange'
+          asset: 'native-currency'
         }
-      })
+      }
 
-      console.log('✅ SUCCESS! Privy funding modal opened with proper useFundWallet hook!')
+      console.log('✅ fundWallet is available, opening Privy funding modal with options:', fundingRequest)
+
+      await fundWallet(fundingRequest)
+
+      console.log('✅ SUCCESS! Privy funding modal opened with selection screen!')
       
     } catch (error) {
       console.error('❌ Solana funding error details:', {


### PR DESCRIPTION
## Summary
- update the Privy `fundWallet` call to only request Solana native currency funding
- allow the Privy modal to present the default funding selection instead of forcing the Coinbase on-ramp flow
- improve logging around the funding request to aid future troubleshooting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e348f0ae5c8330a7c0920c47ecc1a9