### PR TITLE
Remove arena cash-out rake and expose micro cash rooms

### DIFF
--- a/app/legal/page.js
+++ b/app/legal/page.js
@@ -124,7 +124,7 @@ export default function LegalPage() {
               <div>
                 <h3 className="font-bold text-[#14F195] mb-2">6. Financial Terms</h3>
                 <p className="text-muted-foreground leading-relaxed">
-                  A 10% service fee is deducted from gross winnings. Minimum withdrawal amounts may apply. 
+                  TurfLoot does not deduct a platform service fee from gross winnings. Minimum withdrawal amounts may apply.
                   All transactions are processed in SOL cryptocurrency on the Solana blockchain.
                 </p>
               </div>

--- a/components/ServerBrowserModalNew.jsx
+++ b/components/ServerBrowserModalNew.jsx
@@ -369,40 +369,116 @@ const ServerBrowserModal = ({ isOpen, onClose, onJoinLobby }) => {
     console.log('🔄 Using fallback server data due to routing issues')
     
     // Fallback server data when API endpoints are not accessible
+    const timestamp = new Date().toISOString()
+    const fallbackEndpoint = process.env.NEXT_PUBLIC_COLYSEUS_ENDPOINT || 'wss://au-syd-ab3eaf4e.colyseus.cloud'
+
+    const fallbackCashConfigs = [
+      {
+        stake: 0.02,
+        idSuffix: '002',
+        description: 'Micro stakes TurfLoot arena for fast wagers'
+      },
+      {
+        stake: 0.05,
+        idSuffix: '005',
+        description: 'Low stakes TurfLoot arena for casual competitive play'
+      }
+    ]
+
+    const fallbackCashRooms = fallbackCashConfigs.map((config) => {
+      const payout = Number((config.stake * 2).toFixed(2))
+
+      return {
+        id: `colyseus-cash-${config.idSuffix}-au`,
+        roomType: 'cash',
+        type: 'cash-room',
+        name: `TurfLoot $${config.stake.toFixed(2)} Room - Australia`,
+        region: 'Australia',
+        regionId: 'au-syd',
+        displayName: `$${config.stake.toFixed(2)} Cash Game`,
+        mode: 'cash-game',
+        gameType: 'Cash Game',
+        description: config.description,
+        maxPlayers: 50,
+        minPlayers: 2,
+        currentPlayers: 0,
+        waitingPlayers: 0,
+        isRunning: true,
+        ping: null,
+        avgWaitTime: 'Create Game',
+        difficulty: 'All Players',
+        entryFee: config.stake,
+        serverFee: 0,
+        totalCost: config.stake,
+        potentialWinning: payout,
+        prizePool: payout,
+        stake: config.stake,
+        status: 'waiting',
+        serverType: 'colyseus',
+        endpoint: fallbackEndpoint,
+        hathoraRegion: 'ap-southeast-2',
+        lastUpdated: timestamp,
+        timestamp,
+        canJoin: true,
+        canSpectate: false
+      }
+    })
+
+    const fallbackServers = [
+      {
+        id: 'colyseus-arena-global',
+        roomType: 'arena',
+        name: 'TurfLoot Arena',
+        region: 'Australia',
+        regionId: 'au-syd',
+        displayName: 'Global Arena',
+        mode: 'multiplayer',
+        gameType: 'Arena Battle',
+        description: 'Real-time multiplayer arena with up to 50 players',
+        maxPlayers: 50,
+        minPlayers: 1,
+        currentPlayers: 0,
+        waitingPlayers: 0,
+        isRunning: true,
+        ping: 0,
+        avgWaitTime: 'Join Now',
+        difficulty: 'All Players',
+        entryFee: 0,
+        serverFee: 0,
+        totalCost: 0,
+        potentialWinning: 0,
+        prizePool: 0,
+        stake: 0,
+        status: 'waiting',
+        serverType: 'colyseus',
+        endpoint: fallbackEndpoint,
+        hathoraRegion: 'ap-southeast-2',
+        lastUpdated: timestamp,
+        timestamp,
+        canJoin: true,
+        canSpectate: true
+      },
+      ...fallbackCashRooms
+    ]
+
     const fallbackServerData = {
-      servers: [
-        {
-          id: 'colyseus-arena-global',
-          roomType: 'arena',
-          name: 'TurfLoot Arena',
-          region: 'Australia',
-          regionId: 'au-syd',
-          endpoint: process.env.NEXT_PUBLIC_COLYSEUS_ENDPOINT || 'wss://au-syd-ab3eaf4e.colyseus.cloud',
-          maxPlayers: 50,
-          currentPlayers: 0,
-          entryFee: 0,
-          gameType: 'Arena Battle',
-          serverType: 'colyseus',
-          isActive: true,
-          canSpectate: true,
-          ping: 0,
-          lastUpdated: new Date().toISOString(),
-          timestamp: new Date().toISOString()
-        }
-      ],
+      servers: fallbackServers,
       totalPlayers: 0,
-      totalActiveServers: 1,
-      totalServers: 1,
-      practiceServers: 0,
-      cashServers: 0,
+      totalActiveServers: 0,
+      totalServers: fallbackServers.length,
+      practiceServers: 1,
+      cashServers: fallbackCashRooms.length,
       regions: ['Australia'],
-      gameTypes: ['Arena Battle'],
+      gameTypes: [
+        { name: 'Arena Battle', servers: 1 },
+        { name: 'Cash Game', servers: fallbackCashRooms.length }
+      ],
       colyseusEnabled: true,
-      colyseusEndpoint: process.env.NEXT_PUBLIC_COLYSEUS_ENDPOINT || 'wss://au-syd-ab3eaf4e.colyseus.cloud',
-      lastUpdated: new Date().toISOString(),
-      timestamp: new Date().toISOString()
+      colyseusEndpoint: fallbackEndpoint,
+      lastUpdated: timestamp,
+      timestamp
     }
-    
+
     console.log('✅ Using fallback server data:', {
       servers: fallbackServerData.servers.length,
       endpoint: fallbackServerData.colyseusEndpoint,

--- a/components/wallet/WalletManager.jsx
+++ b/components/wallet/WalletManager.jsx
@@ -354,7 +354,7 @@ const WalletManager = ({ onBalanceUpdate }) => {
     try {
       const amount = parseFloat(cashOutForm.amount)
       const minCashOut = cashOutForm.currency === 'SOL' ? 0.05 : 20 // 0.05 SOL or $20 USD
-      const platformFeePercent = 10
+      const platformFeePercent = 0
       const platformFee = amount * (platformFeePercent / 100)
       const netAmount = amount - platformFee
       
@@ -390,9 +390,8 @@ const WalletManager = ({ onBalanceUpdate }) => {
       }
       
       // Confirmation dialog with fee breakdown
-      const feeDisplay = `${platformFee.toFixed(4)} ${cashOutForm.currency}`
       const netDisplay = `${netAmount.toFixed(4)} ${cashOutForm.currency}`
-      const confirmMessage = `Confirm Cash Out:\n\nAmount: ${amount} ${cashOutForm.currency}\nPlatform Fee (10%): ${feeDisplay}\nYou'll receive: ${netDisplay}\n\nProceed?`
+      const confirmMessage = `Confirm Cash Out:\n\nAmount: ${amount} ${cashOutForm.currency}\nYou'll receive: ${netDisplay} (no platform fee)\n\nProceed?`
       
       if (!confirm(confirmMessage)) {
         setLoading(false)
@@ -446,12 +445,14 @@ const WalletManager = ({ onBalanceUpdate }) => {
   // Calculate fee display for cash out
   const getCashOutFeeInfo = () => {
     const amount = parseFloat(cashOutForm.amount) || 0
-    const platformFee = amount * 0.1 // 10% fee
+    const platformFeePercent = 0
+    const platformFee = amount * (platformFeePercent / 100)
     const netAmount = amount - platformFee
-    
+
     return {
       amount: amount,
       fee: platformFee,
+      feePercent: platformFeePercent,
       net: netAmount,
       feeDisplay: `${platformFee.toFixed(4)} ${cashOutForm.currency}`,
       netDisplay: `${netAmount.toFixed(4)} ${cashOutForm.currency}`

--- a/frontend/app/legal/page.js
+++ b/frontend/app/legal/page.js
@@ -124,7 +124,7 @@ export default function LegalPage() {
               <div>
                 <h3 className="font-bold text-[#14F195] mb-2">6. Financial Terms</h3>
                 <p className="text-muted-foreground leading-relaxed">
-                  A 10% service fee is deducted from gross winnings. Minimum withdrawal amounts may apply. 
+                  TurfLoot does not deduct a platform service fee from gross winnings. Minimum withdrawal amounts may apply.
                   All transactions are processed in SOL cryptocurrency on the Solana blockchain.
                 </p>
               </div>

--- a/frontend/components/wallet/WalletManager.jsx
+++ b/frontend/components/wallet/WalletManager.jsx
@@ -398,7 +398,7 @@ const WalletManager = ({ onBalanceUpdate }) => {
     try {
       const amount = parseFloat(cashOutForm.amount)
       const minCashOut = cashOutForm.currency === 'SOL' ? 0.05 : 20 // 0.05 SOL or $20 USD
-      const platformFeePercent = 10
+      const platformFeePercent = 0
       const platformFee = amount * (platformFeePercent / 100)
       const netAmount = amount - platformFee
       
@@ -434,9 +434,8 @@ const WalletManager = ({ onBalanceUpdate }) => {
       }
       
       // Confirmation dialog with fee breakdown
-      const feeDisplay = `${platformFee.toFixed(4)} ${cashOutForm.currency}`
       const netDisplay = `${netAmount.toFixed(4)} ${cashOutForm.currency}`
-      const confirmMessage = `Confirm Cash Out:\n\nAmount: ${amount} ${cashOutForm.currency}\nPlatform Fee (10%): ${feeDisplay}\nYou'll receive: ${netDisplay}\n\nProceed?`
+      const confirmMessage = `Confirm Cash Out:\n\nAmount: ${amount} ${cashOutForm.currency}\nYou'll receive: ${netDisplay} (no platform fee)\n\nProceed?`
       
       if (!confirm(confirmMessage)) {
         setLoading(false)
@@ -490,12 +489,14 @@ const WalletManager = ({ onBalanceUpdate }) => {
   // Calculate fee display for cash out
   const getCashOutFeeInfo = () => {
     const amount = parseFloat(cashOutForm.amount) || 0
-    const platformFee = amount * 0.1 // 10% fee
+    const platformFeePercent = 0
+    const platformFee = amount * (platformFeePercent / 100)
     const netAmount = amount - platformFee
-    
+
     return {
       amount: amount,
       fee: platformFee,
+      feePercent: platformFeePercent,
       net: netAmount,
       feeDisplay: `${platformFee.toFixed(4)} ${cashOutForm.currency}`,
       netDisplay: `${netAmount.toFixed(4)} ${cashOutForm.currency}`


### PR DESCRIPTION
## Summary
- remove the 10% cash-out deduction in the wallet manager so arena earnings are paid in full
- update the legal copy to reflect that winnings are no longer reduced by a service fee
- extend the server browser fallback data so $0.02 and $0.05 cash rooms remain available when the API fails

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e35600670c83309322e83873171175