### PR TITLE
Fix desktop withdrawal modal selection

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -2601,15 +2601,18 @@ export default function TurfLootTactical() {
       console.log('✅ User authenticated via Privy, opening withdrawal modal')
       console.log('👤 User wallet:', privyUser.wallet?.address || 'No wallet')
       
-      // Open different modals for desktop vs mobile
-      if (window.innerWidth >= 768) {
-        // Desktop: Open new desktop modal
-        console.log('🖥️ Opening desktop withdrawal modal')
-        setDesktopWithdrawalModalVisible(true)
-      } else {
-        // Mobile: Use existing modal
+      // Decide which withdrawal modal to show based on responsive state & viewport
+      const shouldUseMobileModal =
+        isMobile || (typeof window !== 'undefined' && window.innerWidth < 768)
+
+      if (shouldUseMobileModal) {
         console.log('📱 Opening mobile withdrawal modal')
         setWithdrawalModalVisible(true)
+        setDesktopWithdrawalModalVisible(false)
+      } else {
+        console.log('🖥️ Opening desktop withdrawal modal')
+        setDesktopWithdrawalModalVisible(true)
+        setWithdrawalModalVisible(false)
       }
       
     } catch (error) {

--- a/frontend/app/page.js
+++ b/frontend/app/page.js
@@ -2633,22 +2633,17 @@ export default function TurfLootTactical() {
         console.log('👤 User wallet information unavailable (optional)')
       }
 
-      const isDesktopView = (() => {
-        if (typeof window === 'undefined') {
-          console.warn('⚠️ Window object unavailable, falling back to layout state for modal selection')
-          return !isMobile
-        }
-        return window.innerWidth >= 768
-      })()
+      const shouldUseMobileModal =
+        isMobile || (typeof window !== 'undefined' && window.innerWidth < 768)
 
-      if (isDesktopView) {
-        // Desktop: Open new desktop modal
-        console.log('🖥️ Opening desktop withdrawal modal')
-        setDesktopWithdrawalModalVisible(true)
-      } else {
-        // Mobile: Use existing modal
+      if (shouldUseMobileModal) {
         console.log('📱 Opening mobile withdrawal modal')
         setWithdrawalModalVisible(true)
+        setDesktopWithdrawalModalVisible(false)
+      } else {
+        console.log('🖥️ Opening desktop withdrawal modal')
+        setDesktopWithdrawalModalVisible(true)
+        setWithdrawalModalVisible(false)
       }
 
     } catch (error) {


### PR DESCRIPTION
## Summary
- ensure the withdrawal handler decides between desktop and mobile modals using the responsive state instead of raw viewport width
- prevent both withdrawal modals from showing simultaneously by toggling the opposite modal closed when the other is opened

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e35c7112888330b866442ed6ef6daa