### PR TITLE
Remove live latency text from ping indicator

### DIFF
--- a/app/arena/page.js
+++ b/app/arena/page.js
@@ -238,7 +238,7 @@ const MultiplayerArena = () => {
     if (connectionStatus === 'eliminated') {
       return pingMs == null ? 'Eliminated' : 'Spectator latency'
     }
-    return pingMs == null ? 'Measuring latency' : 'Live latency'
+    return pingMs == null ? 'Measuring latency' : ''
   }, [connectionStatus, pingMs])
   
   // Parse URL parameters and get authenticated user data
@@ -3629,8 +3629,8 @@ const MultiplayerArena = () => {
             style={{
               display: 'flex',
               alignItems: 'center',
-              justifyContent: 'space-between',
-              gap: '10px',
+              justifyContent: 'flex-start',
+              gap: '6px',
               marginBottom: '4px'
             }}
           >

--- a/frontend/app/agario/page.js
+++ b/frontend/app/agario/page.js
@@ -255,7 +255,7 @@ const AgarIOGame = () => {
     if (wsConnection === 'connecting') return 'Connecting…'
     if (wsConnection === 'error') return 'Connection error'
     if (wsConnection === 'disconnected') return 'Waiting for arena'
-    return pingMs == null ? 'Measuring latency' : 'Live latency'
+    return pingMs == null ? 'Measuring latency' : ''
   })()
 
   const ensurePlayerIdentifier = useCallback(() => {
@@ -5270,7 +5270,7 @@ const AgarIOGame = () => {
           <div style={{
             display: 'flex',
             alignItems: 'center',
-            gap: '8px'
+            gap: '6px'
           }}>
             <div style={{
               width: '10px',


### PR DESCRIPTION
## Summary
- drop the "Live latency" subtitle once latency is known to declutter the ping meter
- move the latency readout closer to the indicator dot on both Arena and Agario views for a tighter layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3d65ce320833084e2b40867262e02