### PR TITLE
Ensure split button shows cooldown state immediately

### DIFF
--- a/frontend/app/agario/page.js
+++ b/frontend/app/agario/page.js
@@ -4286,6 +4286,10 @@ const AgarIOGame = () => {
       }
       
       gameRef.current.split()
+
+      const cooldownFrames = Math.max(0, Math.ceil(gameRef.current.splitCooldown ?? 0)) || 60
+      setSplitCooldownRemaining(cooldownFrames)
+      setCanSplit(false)
     }
   }
 


### PR DESCRIPTION
## Summary
- update the arena split handler to immediately sync the cooldown state after a split
- force the button into its disabled (grey) state as soon as the split triggers so players see the cooldown feedback right away

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3d82da7c083308eaf576de53fb1ae