### PR TITLE
Remove arena disconnected debug message

### DIFF
--- a/app/arena/page.js
+++ b/app/arena/page.js
@@ -3492,7 +3492,7 @@ const MultiplayerArena = () => {
               {connectionStatus === 'connected' && `🌐 MULTIPLAYER (${playerCount} players)`}
               {connectionStatus === 'connecting' && '🔄 CONNECTING...'}
               {connectionStatus === 'failed' && '❌ CONNECTION ERROR'}
-              {connectionStatus === 'disconnected' && '🔌 DISCONNECTED'}
+              {connectionStatus === 'disconnected' && null}
               {connectionStatus === 'eliminated' && '☠️ ELIMINATED'}
             </span>
           </div>


### PR DESCRIPTION
## Summary
- stop rendering the temporary "🔌 DISCONNECTED" status indicator in the arena connection banner

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3d94077348330978a7eb27ccf9827