### PR TITLE
Ensure black minimap background in arena mode

### DIFF
--- a/app/arena/page.js
+++ b/app/arena/page.js
@@ -3932,6 +3932,7 @@ const MultiplayerArena = () => {
             height: isMobile ? '121px' : '220px',
             borderRadius: '50%',
             backgroundColor: '#000000', // Pure black background
+            backgroundImage: 'none', // Prevent any inherited gradients
             border: isMobile ? '2px solid #00ff00' : '4px solid #00ff00',
             position: 'relative',
             overflow: 'hidden'

--- a/app/globals.css
+++ b/app/globals.css
@@ -1291,7 +1291,7 @@
   right: 20px;
   width: 120px;
   height: 120px;
-  background: rgba(0, 0, 0, 0.7);
+  background: #000000;
   border: 2px solid rgba(255, 255, 255, 0.3);
   border-radius: 50%;
   z-index: 1000;


### PR DESCRIPTION
## Summary
- force the arena minimap container to render with a pure black background so no gradients bleed through
- update the mobile minimap styling to use the same solid black background treatment

## Testing
- NEXT_PUBLIC_PRIVY_APP_ID=demo npm run dev -- --hostname 0.0.0.0 --port 3000

------
https://chatgpt.com/codex/tasks/task_e_68e3da5982708330bdc19e5cae15dbaa