### PR TITLE
Fix Solana websocket alias for Next build

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -131,7 +131,7 @@ const nextConfig = {
       // Fix WalletConnect nested dependency issues
       '@walletconnect/universal-provider': path.resolve(__dirname, 'node_modules/@walletconnect/universal-provider/dist/index.umd.js'),
       '@walletconnect/ethereum-provider': path.resolve(__dirname, 'node_modules/@walletconnect/ethereum-provider/dist/index.umd.js'),
-      'rpc-websockets': false,
+      'rpc-websockets': path.resolve(__dirname, 'node_modules/rpc-websockets/dist/index.browser.mjs'),
       'require-addon': false,
       'bare-os': false,
       // Additional aliases for problematic modules


### PR DESCRIPTION
## Summary
- update the webpack alias for rpc-websockets to point at the browser build so Solana web3 client classes resolve correctly

## Testing
- npm run build *(fails: blocked fetching Google Fonts in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e48260ab9c83308dad8b7056963424