### PR TITLE
Add safe Privy hook fallbacks for missing SDK environments

### DIFF
--- a/app/agario/page.js
+++ b/app/agario/page.js
@@ -1124,7 +1124,7 @@ const AgarIOGame = () => {
 
         // Try to get Privy user info if available
         try {
-          const { usePrivy } = await import('@privy-io/react-auth')
+          const { usePrivy } = await import('../../frontend/utils/privyClient')
           const { user } = usePrivy()
           privyUserId = user?.id || `anonymous_${Date.now()}`
           playerName = user?.username || user?.email?.split('@')[0] || null

--- a/app/arena/page.js
+++ b/app/arena/page.js
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { Client } from 'colyseus.js'
-import { usePrivy } from '@privy-io/react-auth'
+import { usePrivy } from '../../frontend/utils/privyClient'
 
 // Global connection tracker to prevent duplicates across component instances
 const GLOBAL_CONNECTION_TRACKER = {

--- a/app/page.js
+++ b/app/page.js
@@ -2,8 +2,7 @@
 
 import { useState, useEffect, useRef, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
-import { usePrivy, useWallets } from '@privy-io/react-auth'
-import { useFundWallet } from '@privy-io/react-auth/solana'
+import { usePrivy, useWallets, useFundWallet } from '../frontend/utils/privyClient'
 import { Connection, PublicKey, SystemProgram, Transaction, LAMPORTS_PER_SOL } from '@solana/web3.js'
 import ServerBrowserModal from '../components/ServerBrowserModalNew'
 

--- a/app/play/page.js
+++ b/app/play/page.js
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useRef } from 'react'
-import { usePrivy } from '@privy-io/react-auth'
+import { usePrivy } from '../../frontend/utils/privyClient'
 import { useRouter } from 'next/navigation'
 
 const TurfLootGame = () => {

--- a/app/test-privy-solana/page.js
+++ b/app/test-privy-solana/page.js
@@ -1,7 +1,7 @@
 'use client'
 
 import React, { useMemo, useState } from 'react'
-import { usePrivy, useWallets } from '@privy-io/react-auth'
+import { usePrivy, useWallets } from '../../frontend/utils/privyClient'
 
 function pickDefaultSolanaWallet(wallets) {
   return (

--- a/frontend/app/agario/page.js
+++ b/frontend/app/agario/page.js
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { usePrivy } from '@privy-io/react-auth'
+import { usePrivy } from '../../utils/privyClient'
 import { v4 as uuidv4 } from 'uuid'
 import MissionPopupMobile from '../../components/missions/MissionPopupMobile'
 

--- a/frontend/app/page.js
+++ b/frontend/app/page.js
@@ -2,9 +2,9 @@
 
 import { useState, useEffect, useRef, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
-import { usePrivy, useWallets, useFundWallet } from '@privy-io/react-auth'
+import { usePrivy, useWallets, useFundWallet } from '../utils/privyClient'
 import { Connection, PublicKey, SystemProgram, Transaction, LAMPORTS_PER_SOL } from '@solana/web3.js'
-// NOTE: Should be '@privy-io/react-auth/solana' per docs, but causes compatibility issues
+// Privy hooks are wrapped by ../utils/privyClient to provide safe fallbacks when SDK hooks are unavailable
 import ServerBrowserModal from '../components/ServerBrowserModalNew'
 
 export default function TurfLootTactical() {

--- a/frontend/app/play/page.js
+++ b/frontend/app/play/page.js
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useRef } from 'react'
-import { usePrivy } from '@privy-io/react-auth'
+import { usePrivy } from '../../utils/privyClient'
 import { useRouter } from 'next/navigation'
 
 const TurfLootGame = () => {

--- a/frontend/app/test-privy-solana/page.js
+++ b/frontend/app/test-privy-solana/page.js
@@ -1,7 +1,7 @@
 'use client'
 
 import React, { useMemo, useState } from 'react'
-import { usePrivy, useWallets } from '@privy-io/react-auth'
+import { usePrivy, useWallets } from '../../utils/privyClient'
 
 function pickDefaultSolanaWallet(wallets) {
   return (

--- a/frontend/components/SimpleSpectatorMode.jsx
+++ b/frontend/components/SimpleSpectatorMode.jsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
-import { usePrivy } from '@privy-io/react-auth'
+import { usePrivy } from '../utils/privyClient'
 // Socket.IO removed - using native WebSocket implementation
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'

--- a/frontend/components/SolanaFundingHandler.js
+++ b/frontend/components/SolanaFundingHandler.js
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { usePrivy } from '@privy-io/react-auth'
+import { usePrivy } from '../utils/privyClient'
 
 // Client-only component to handle Solana funding
 export default function SolanaFundingHandler({ onFundWalletReady }) {

--- a/frontend/components/SpectatorMode.jsx
+++ b/frontend/components/SpectatorMode.jsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
-import { usePrivy } from '@privy-io/react-auth'
+import { usePrivy } from '../utils/privyClient'
 // Socket.IO removed - using native WebSocket implementation
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'

--- a/frontend/components/auth/LoginModal.jsx
+++ b/frontend/components/auth/LoginModal.jsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { usePrivy } from '@privy-io/react-auth'
+import { usePrivy } from '../../utils/privyClient'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { X } from 'lucide-react'

--- a/frontend/components/lobby/LobbySystem.jsx
+++ b/frontend/components/lobby/LobbySystem.jsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { usePrivy } from '@privy-io/react-auth'
+import { usePrivy } from '../../utils/privyClient'
 import { Users, Plus, Globe, Lock, Crown, Check, X, MessageCircle, Play, Copy, RefreshCw, Wifi } from 'lucide-react'
 // Socket.IO removed - using native WebSocket implementation
 

--- a/frontend/components/social/FriendsPanel.jsx
+++ b/frontend/components/social/FriendsPanel.jsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { usePrivy } from '@privy-io/react-auth'
+import { usePrivy } from '../../utils/privyClient'
 
 // Crypto polyfill for older browsers
 const generateId = () => {

--- a/frontend/utils/privyClient.js
+++ b/frontend/utils/privyClient.js
@@ -1,0 +1,57 @@
+'use client'
+
+import * as PrivyReactAuth from '@privy-io/react-auth'
+
+let warned = false
+const warnOnce = (message) => {
+  if (!warned) {
+    console.warn(message)
+    warned = true
+  }
+}
+
+const fallbackPrivyValue = {
+  ready: false,
+  authenticated: false,
+  user: null,
+  login: async () => {
+    warnOnce('Privy authentication is unavailable; falling back to mock handlers.')
+    return null
+  },
+  logout: async () => {
+    warnOnce('Privy authentication is unavailable; falling back to mock handlers.')
+    return null
+  },
+  getAccessToken: async () => {
+    warnOnce('Privy authentication is unavailable; falling back to mock handlers.')
+    return null
+  },
+  connectWallet: async () => {
+    warnOnce('Privy authentication is unavailable; falling back to mock handlers.')
+    return null
+  },
+  linkWallet: async () => {
+    warnOnce('Privy authentication is unavailable; falling back to mock handlers.')
+    return null
+  }
+}
+
+const fallbackWalletsValue = { wallets: [] }
+
+const fallbackFundWalletValue = {
+  fundWallet: async () => {
+    warnOnce('Privy wallet funding is unavailable in this environment.')
+    throw new Error('Privy wallet funding is not available')
+  }
+}
+
+const ensureHook = (hook, fallbackValue) => {
+  if (typeof hook === 'function') {
+    return hook
+  }
+  return () => fallbackValue
+}
+
+export const usePrivy = ensureHook(PrivyReactAuth.usePrivy, fallbackPrivyValue)
+export const useWallets = ensureHook(PrivyReactAuth.useWallets, fallbackWalletsValue)
+export const useFundWallet = ensureHook(PrivyReactAuth.useFundWallet, fallbackFundWalletValue)


### PR DESCRIPTION
## Summary
- add a client-only wrapper around Privy hooks that returns graceful fallbacks when the SDK exports are missing
- update pages and shared components to consume the wrapper instead of importing hooks directly from `@privy-io/react-auth`
- adjust dynamic Privy usage in the legacy arena page to load the wrapper module

## Testing
- npm run lint *(fails: existing lint errors in unrelated legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68e486e545f083309300f516ef4c98af