### PR TITLE
feat: add paid room intent orchestration backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ next-env.d.ts
 # Production builds
 /build
 dist/
-lib/
 
 # Environment files
 .env

--- a/app/api/paid/intent/[intentId]/signature/route.js
+++ b/app/api/paid/intent/[intentId]/signature/route.js
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { submitIntentSignature } from '../../../../../../lib/paid/intentService.js';
+import { scheduleIntentVerification, ensurePaidRoomWatchers } from '../../../../../../lib/paid/watchers.js';
+
+ensurePaidRoomWatchers();
+
+export async function POST(request, { params }) {
+  try {
+    const { intentId } = params;
+    const body = await request.json();
+    const { signature } = body || {};
+
+    if (!signature) {
+      return NextResponse.json({ error: 'Signature is required' }, { status: 400 });
+    }
+
+    const intent = await submitIntentSignature(intentId, signature);
+    scheduleIntentVerification(intent.intentId, 0);
+
+    return NextResponse.json({ status: intent.status, signature });
+  } catch (error) {
+    console.error('❌ Failed to store intent signature:', error);
+    return NextResponse.json({ error: error.message || 'Failed to store signature' }, { status: 400 });
+  }
+}

--- a/app/api/paid/intent/[intentId]/ticket/route.js
+++ b/app/api/paid/intent/[intentId]/ticket/route.js
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { getJoinTicketForIntent } from '../../../../../../lib/paid/intentService.js';
+import { PaymentIntentStatus } from '../../../../../../lib/paid/constants.js';
+import { ensurePaidRoomWatchers } from '../../../../../../lib/paid/watchers.js';
+
+ensurePaidRoomWatchers();
+
+export async function GET(_request, { params }) {
+  try {
+    const { intentId } = params;
+    const ticketInfo = await getJoinTicketForIntent(intentId);
+    if (!ticketInfo) {
+      return NextResponse.json({ error: 'Intent not found' }, { status: 404 });
+    }
+
+    if (ticketInfo.status !== PaymentIntentStatus.CONFIRMED) {
+      const statusCode = ticketInfo.status === PaymentIntentStatus.EXPIRED ? 410 : 202;
+      return NextResponse.json({ status: ticketInfo.status }, { status: statusCode });
+    }
+
+    return NextResponse.json({
+      status: PaymentIntentStatus.CONFIRMED,
+      joinTicket: {
+        token: ticketInfo.joinTicket.token,
+        expiresAt: ticketInfo.joinTicket.expiresAt instanceof Date
+          ? ticketInfo.joinTicket.expiresAt.toISOString()
+          : ticketInfo.joinTicket.expiresAt
+      }
+    });
+  } catch (error) {
+    console.error('❌ Failed to load join ticket:', error);
+    return NextResponse.json({ error: error.message || 'Failed to load join ticket' }, { status: 500 });
+  }
+}

--- a/app/api/paid/intent/route.js
+++ b/app/api/paid/intent/route.js
@@ -1,0 +1,78 @@
+import { NextResponse } from 'next/server';
+import { createPaymentIntent, getRateLimitKey } from '../../../../lib/paid/intentService.js';
+import { ensurePaidRoomWatchers } from '../../../../lib/paid/watchers.js';
+
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX = Number(process.env.PAID_ROOMS_INTENT_RATE_LIMIT || 5);
+
+const rateLimitStore = globalThis.__PAID_ROOMS_RATE_LIMIT__ || new Map();
+if (!globalThis.__PAID_ROOMS_RATE_LIMIT__) {
+  globalThis.__PAID_ROOMS_RATE_LIMIT__ = rateLimitStore;
+}
+
+function checkRateLimit(request, userId) {
+  const key = getRateLimitKey(request, userId);
+  const now = Date.now();
+  const record = rateLimitStore.get(key) || { count: 0, resetAt: now + RATE_LIMIT_WINDOW_MS };
+
+  if (record.resetAt < now) {
+    record.count = 0;
+    record.resetAt = now + RATE_LIMIT_WINDOW_MS;
+  }
+
+  record.count += 1;
+  rateLimitStore.set(key, record);
+
+  if (record.count > RATE_LIMIT_MAX) {
+    const retryAfter = Math.ceil((record.resetAt - now) / 1000);
+    throw new Response(JSON.stringify({ error: 'RATE_LIMITED', retryAfter }), {
+      status: 429,
+      headers: {
+        'Content-Type': 'application/json',
+        'Retry-After': retryAfter.toString()
+      }
+    });
+  }
+}
+
+ensurePaidRoomWatchers();
+
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    const { userId, gameId, roomId, playerPubkey } = body || {};
+
+    if (!userId || !gameId || !roomId || !playerPubkey) {
+      return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+    }
+
+    try {
+      checkRateLimit(request, userId);
+    } catch (responseError) {
+      if (responseError instanceof Response) {
+        return responseError;
+      }
+      throw responseError;
+    }
+
+    const intent = await createPaymentIntent({ userId, gameId, roomId, playerPubkey });
+
+    return NextResponse.json({
+      intentId: intent.intentId,
+      serializedMessage: intent.serializedMessage,
+      memoJson: intent.memoJson,
+      lamports: intent.lamports,
+      feeBps: intent.feeBps,
+      recipient: intent.recipient,
+      recentBlockhash: intent.recentBlockhash,
+      lastValidBlockHeight: intent.lastValidBlockHeight,
+      expiresAt: intent.expiresAt.toISOString()
+    });
+  } catch (error) {
+    if (error instanceof Response) {
+      return error;
+    }
+    console.error('❌ Failed to create payment intent:', error);
+    return NextResponse.json({ error: error.message || 'Failed to create payment intent' }, { status: 500 });
+  }
+}

--- a/app/api/paid/room/[roomId]/quote/route.js
+++ b/app/api/paid/room/[roomId]/quote/route.js
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { getRoomQuote } from '../../../../../../lib/paid/config.js';
+import { ensurePaidRoomWatchers } from '../../../../../../lib/paid/watchers.js';
+
+ensurePaidRoomWatchers();
+
+export async function GET(_request, { params }) {
+  try {
+    const { roomId } = params;
+    const quote = getRoomQuote(roomId);
+    if (!quote) {
+      return NextResponse.json({ error: 'Room not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({
+      roomId: quote.roomId,
+      entryLamports: quote.entryLamports,
+      feeLamports: quote.feeLamports,
+      totalLamports: quote.totalLamports,
+      feeBps: quote.feeBps,
+      recipient: quote.recipient,
+      currencyDisplay: quote.currencyDisplay,
+      priorityFeeMicroLamports: quote.priorityFeeMicroLamports
+    });
+  } catch (error) {
+    console.error('❌ Failed to load paid room quote:', error);
+    return NextResponse.json({ error: error.message || 'Failed to load room quote' }, { status: 500 });
+  }
+}

--- a/lib/paid/config.js
+++ b/lib/paid/config.js
@@ -1,0 +1,133 @@
+import { LAMPORTS_PER_SOL, PublicKey } from '@solana/web3.js';
+import { DEFAULT_JOIN_TICKET_TTL_SECONDS, MIN_JOIN_TICKET_TTL_SECONDS, MAX_JOIN_TICKET_TTL_SECONDS } from './constants.js';
+
+const DEFAULT_PRIORITY_FEE_MICRO_LAMPORTS = Number(process.env.PAID_ROOMS_PRIORITY_FEE_MICRO_LAMPORTS || 5000);
+const DEFAULT_SEAT_HOLD_MS = Number(process.env.PAID_ROOMS_SEAT_HOLD_MS || 60_000);
+
+const FALLBACK_ROOMS = [
+  {
+    id: 'practice',
+    name: 'Practice Grounds',
+    entryLamports: 0,
+    feeBps: 0,
+    currencyDisplay: 'SOL'
+  },
+  {
+    id: 'brawl',
+    name: 'Brawl Bronze',
+    entryLamports: 5_000_000, // 0.005 SOL
+    feeBps: 800,
+    currencyDisplay: 'SOL'
+  },
+  {
+    id: 'showdown',
+    name: 'Showdown Silver',
+    entryLamports: 20_000_000, // 0.02 SOL
+    feeBps: 900,
+    currencyDisplay: 'SOL'
+  }
+];
+
+function parseRoomConfigFromEnv() {
+  const raw = process.env.PAID_ROOMS_CONFIG;
+  if (!raw) {
+    return FALLBACK_ROOMS;
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      console.warn('⚠️ PAID_ROOMS_CONFIG must be an array of room configs');
+      return FALLBACK_ROOMS;
+    }
+
+    return parsed.map((room) => ({
+      ...room,
+      entryLamports: Number(room.entryLamports ?? 0),
+      feeBps: Number(room.feeBps ?? 0),
+      currencyDisplay: room.currencyDisplay || 'SOL',
+      priorityFeeMicroLamports: Number(room.priorityFeeMicroLamports || DEFAULT_PRIORITY_FEE_MICRO_LAMPORTS)
+    }));
+  } catch (error) {
+    console.error('❌ Failed to parse PAID_ROOMS_CONFIG:', error);
+    return FALLBACK_ROOMS;
+  }
+}
+
+const ROOM_CONFIGS = parseRoomConfigFromEnv();
+
+const FEE_WALLET = process.env.PAID_ROOMS_FEE_WALLET || process.env.NEXT_PUBLIC_FEE_WALLET || process.env.PLATFORM_FEE_WALLET;
+
+if (!FEE_WALLET) {
+  console.warn('⚠️ No PAID_ROOMS_FEE_WALLET configured - using fallback wallet for development only');
+}
+
+function normalizeRoomConfig(room) {
+  if (!room) return null;
+  return {
+    id: room.id,
+    name: room.name,
+    entryLamports: Number(room.entryLamports || 0),
+    feeBps: Number(room.feeBps || 0),
+    currencyDisplay: room.currencyDisplay || 'SOL',
+    recipient: room.recipient || FEE_WALLET,
+    priorityFeeMicroLamports: Number(room.priorityFeeMicroLamports || DEFAULT_PRIORITY_FEE_MICRO_LAMPORTS)
+  };
+}
+
+export function getRoomConfig(roomId) {
+  const room = ROOM_CONFIGS.find((cfg) => cfg.id === roomId);
+  return normalizeRoomConfig(room);
+}
+
+export function getAllRoomConfigs() {
+  return ROOM_CONFIGS.map((cfg) => normalizeRoomConfig(cfg)).filter(Boolean);
+}
+
+export function getRoomQuote(roomId) {
+  const config = getRoomConfig(roomId);
+  if (!config) {
+    return null;
+  }
+
+  if (!config.recipient) {
+    throw new Error('Paid room recipient wallet not configured');
+  }
+
+  const feeLamports = Math.ceil((config.entryLamports * config.feeBps) / 10_000);
+  const totalLamports = config.entryLamports + feeLamports;
+
+  return {
+    roomId: config.id,
+    entryLamports: config.entryLamports,
+    feeLamports,
+    totalLamports,
+    feeBps: config.feeBps,
+    recipient: new PublicKey(config.recipient).toBase58(),
+    currencyDisplay: config.currencyDisplay,
+    priorityFeeMicroLamports: config.priorityFeeMicroLamports
+  };
+}
+
+export function getSeatHoldMilliseconds() {
+  return DEFAULT_SEAT_HOLD_MS;
+}
+
+export function getJoinTicketTtlSeconds() {
+  const configured = Number(process.env.PAID_ROOMS_JOIN_TICKET_TTL_SECONDS || DEFAULT_JOIN_TICKET_TTL_SECONDS);
+  if (Number.isNaN(configured)) {
+    return DEFAULT_JOIN_TICKET_TTL_SECONDS;
+  }
+  return Math.min(Math.max(configured, MIN_JOIN_TICKET_TTL_SECONDS), MAX_JOIN_TICKET_TTL_SECONDS);
+}
+
+export function getPriorityFeeMicroLamports(roomId) {
+  const config = getRoomConfig(roomId);
+  return config?.priorityFeeMicroLamports ?? DEFAULT_PRIORITY_FEE_MICRO_LAMPORTS;
+}
+
+export function lamportsToSol(lamports) {
+  return lamports / LAMPORTS_PER_SOL;
+}
+
+export const memoIssuer = 'turfloot-paid-rooms';

--- a/lib/paid/constants.js
+++ b/lib/paid/constants.js
@@ -1,0 +1,12 @@
+export const PaymentIntentStatus = Object.freeze({
+  CREATED: 'CREATED',
+  SENT: 'SENT',
+  CONFIRMED: 'CONFIRMED',
+  CONSUMED: 'CONSUMED',
+  EXPIRED: 'EXPIRED',
+  MISMATCH: 'MISMATCH'
+});
+
+export const DEFAULT_JOIN_TICKET_TTL_SECONDS = 90;
+export const MIN_JOIN_TICKET_TTL_SECONDS = 60;
+export const MAX_JOIN_TICKET_TTL_SECONDS = 120;

--- a/lib/paid/intentService.js
+++ b/lib/paid/intentService.js
@@ -1,0 +1,533 @@
+import { randomUUID } from 'crypto';
+import jwt from 'jsonwebtoken';
+import { TransactionInstruction, TransactionMessage } from '@solana/web3.js';
+import { connectToDatabase } from '../mongodb.js';
+import {
+  getJoinTicketTtlSeconds,
+  getRoomQuote,
+  getSeatHoldMilliseconds,
+  memoIssuer
+} from './config.js';
+import { PaymentIntentStatus } from './constants.js';
+import {
+  PublicKey,
+  SystemProgram,
+  MEMO_PROGRAM_ID,
+  buildPriorityFeeInstruction,
+  clearBlockhashCache,
+  getLatestBlockhashWithCache,
+  getParsedTransactionWithRetries,
+  getRawTransactionWithRetries
+} from '../solana.js';
+
+const COLLECTION_PAYMENT_INTENTS = 'paymentIntents';
+const COLLECTION_TX_AUDIT = 'paidRoomTxAudits';
+const JOIN_TICKET_SECRET = process.env.PAID_ROOMS_JWT_SECRET || process.env.JWT_SECRET;
+const JWT_ISSUER = memoIssuer;
+
+if (!JOIN_TICKET_SECRET) {
+  console.warn('⚠️ Paid room JWT secret not configured - using development fallback. Set PAID_ROOMS_JWT_SECRET.');
+}
+
+async function getCollections() {
+  const { db } = await connectToDatabase();
+  return {
+    intents: db.collection(COLLECTION_PAYMENT_INTENTS),
+    audits: db.collection(COLLECTION_TX_AUDIT)
+  };
+}
+
+let indexesEnsured = false;
+
+async function ensureIndexes() {
+  if (indexesEnsured) return;
+  const { intents, audits } = await getCollections();
+  await intents.createIndexes([
+    { key: { intentId: 1 }, unique: true },
+    { key: { status: 1, expiresAt: 1 } },
+    { key: { signature: 1 }, unique: true, sparse: true }
+  ]);
+  await audits.createIndexes([
+    { key: { signature: 1 }, unique: true },
+    { key: { intentId: 1 } },
+    { key: { timestamp: -1 } }
+  ]);
+  indexesEnsured = true;
+}
+
+function validateIntentRequest({ userId, gameId, roomId, playerPubkey }) {
+  if (!userId || !gameId || !roomId || !playerPubkey) {
+    throw new Error('Missing required fields for payment intent');
+  }
+
+  try {
+    // Validate public key format
+    // eslint-disable-next-line no-new
+    new PublicKey(playerPubkey);
+  } catch (error) {
+    throw new Error('Invalid player public key');
+  }
+}
+
+function buildMemoBuffer(memoJson) {
+  const memoString = JSON.stringify(memoJson);
+  return Buffer.from(memoString, 'utf8');
+}
+
+function extractMemoText(parsedInstruction) {
+  if (!parsedInstruction) return null;
+  if (typeof parsedInstruction.parsed === 'string') {
+    return parsedInstruction.parsed;
+  }
+  if (parsedInstruction.parsed?.type === 'memo') {
+    return parsedInstruction.parsed.info.memo;
+  }
+  if (parsedInstruction.parsed?.memo) {
+    return parsedInstruction.parsed.memo;
+  }
+  if (parsedInstruction.data) {
+    try {
+      return Buffer.from(parsedInstruction.data, 'base64').toString('utf8');
+    } catch (error) {
+      console.warn('⚠️ Unable to decode memo data:', error);
+    }
+  }
+  return null;
+}
+
+function safeJsonParse(value) {
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    return null;
+  }
+}
+
+function createMemoInstruction(memoJson) {
+  const memoBuffer = buildMemoBuffer(memoJson);
+  return new TransactionInstruction({
+    keys: [],
+    programId: new PublicKey(MEMO_PROGRAM_ID),
+    data: memoBuffer
+  });
+}
+
+async function buildServerMessage({
+  playerPubkey,
+  recipient,
+  lamports,
+  memoJson,
+  priorityFeeMicroLamports
+}) {
+  const payer = new PublicKey(playerPubkey);
+  const to = new PublicKey(recipient);
+  const { blockhash, lastValidBlockHeight } = await getLatestBlockhashWithCache();
+
+  const instructions = [
+    buildPriorityFeeInstruction(priorityFeeMicroLamports),
+    SystemProgram.transfer({
+      fromPubkey: payer,
+      toPubkey: to,
+      lamports
+    }),
+    createMemoInstruction(memoJson)
+  ];
+
+  const message = new TransactionMessage({
+    payerKey: payer,
+    recentBlockhash: blockhash,
+    instructions
+  }).compileToV0Message();
+
+  const serializedMessage = Buffer.from(message.serialize()).toString('base64');
+
+  return {
+    serializedMessage,
+    blockhash,
+    lastValidBlockHeight
+  };
+}
+
+export async function createPaymentIntent(payload) {
+  await ensureIndexes();
+  validateIntentRequest(payload);
+
+  const quote = getRoomQuote(payload.roomId);
+  if (!quote) {
+    throw new Error('Room not found');
+  }
+
+  const intentId = randomUUID();
+  const memoJson = {
+    userId: payload.userId,
+    gameId: payload.gameId,
+    roomId: payload.roomId,
+    intentId
+  };
+
+  const seatHoldMs = getSeatHoldMilliseconds();
+  const expiresAt = new Date(Date.now() + seatHoldMs);
+
+  const { serializedMessage, blockhash, lastValidBlockHeight } = await buildServerMessage({
+    playerPubkey: payload.playerPubkey,
+    recipient: quote.recipient,
+    lamports: quote.totalLamports,
+    memoJson,
+    priorityFeeMicroLamports: quote.priorityFeeMicroLamports
+  });
+
+  const { intents } = await getCollections();
+  const now = new Date();
+
+  const intentDoc = {
+    intentId,
+    userId: payload.userId,
+    gameId: payload.gameId,
+    roomId: payload.roomId,
+    playerPubkey: new PublicKey(payload.playerPubkey).toBase58(),
+    lamports: quote.totalLamports,
+    feeBps: quote.feeBps,
+    recipient: quote.recipient,
+    memoJson,
+    expiresAt,
+    seatHeldUntil: expiresAt,
+    status: PaymentIntentStatus.CREATED,
+    createdAt: now,
+    updatedAt: now,
+    recentBlockhash: blockhash,
+    lastValidBlockHeight
+  };
+
+  await intents.insertOne(intentDoc);
+
+  return {
+    intentId,
+    memoJson,
+    lamports: quote.totalLamports,
+    feeBps: quote.feeBps,
+    recipient: quote.recipient,
+    serializedMessage,
+    recentBlockhash: blockhash,
+    lastValidBlockHeight,
+    expiresAt: intentDoc.expiresAt
+  };
+}
+
+export async function getIntentById(intentId) {
+  await ensureIndexes();
+  const { intents } = await getCollections();
+  return intents.findOne({ intentId });
+}
+
+export async function submitIntentSignature(intentId, signature) {
+  await ensureIndexes();
+  if (!signature) {
+    throw new Error('Signature is required');
+  }
+
+  const { intents } = await getCollections();
+
+  const update = await intents.findOneAndUpdate(
+    {
+      intentId,
+      status: { $in: [PaymentIntentStatus.CREATED, PaymentIntentStatus.SENT, PaymentIntentStatus.MISMATCH] },
+      $or: [{ signature: { $exists: false } }, { signature: null }]
+    },
+    {
+      $set: {
+        signature,
+        status: PaymentIntentStatus.SENT,
+        updatedAt: new Date()
+      }
+    },
+    { returnDocument: 'after' }
+  );
+
+  if (!update.value) {
+    throw new Error('Intent not found or already has a signature');
+  }
+
+  return update.value;
+}
+
+function validateMemoAgainstIntent(intent, memoJson) {
+  if (!memoJson) return false;
+  return (
+    memoJson.intentId === intent.intentId &&
+    memoJson.userId === intent.userId &&
+    memoJson.gameId === intent.gameId &&
+    memoJson.roomId === intent.roomId
+  );
+}
+
+async function recordTxAudit({ intent, signature, parsedTx, rawTxBase64 }) {
+  const { audits } = await getCollections();
+  const transferIx = parsedTx.transaction.message.instructions.find(
+    (ix) => ix.program === 'system' && ix.parsed?.type === 'transfer'
+  );
+  if (!transferIx) return;
+
+  const timestamp = parsedTx.blockTime ? new Date(parsedTx.blockTime * 1000) : new Date();
+
+  await audits.updateOne(
+    { signature },
+    {
+      $set: {
+        signature,
+        intentId: intent.intentId,
+        from: transferIx.parsed.info.source,
+        to: transferIx.parsed.info.destination,
+        lamports: Number(transferIx.parsed.info.lamports),
+        slot: parsedTx.slot,
+        timestamp,
+        memoJson: intent.memoJson,
+        rawTransaction: rawTxBase64
+      }
+    },
+    { upsert: true }
+  );
+}
+
+function buildJoinTicketPayload(intent) {
+  return {
+    sub: intent.userId,
+    userId: intent.userId,
+    gameId: intent.gameId,
+    roomId: intent.roomId,
+    intentId: intent.intentId,
+    type: 'join-ticket',
+    iat: Math.floor(Date.now() / 1000)
+  };
+}
+
+function signJoinTicket(payload, ttlSeconds) {
+  if (!JOIN_TICKET_SECRET) {
+    throw new Error('Join ticket secret not configured');
+  }
+  const expiresIn = `${ttlSeconds}s`;
+  return jwt.sign(payload, JOIN_TICKET_SECRET, {
+    expiresIn,
+    issuer: JWT_ISSUER,
+    jwtid: randomUUID()
+  });
+}
+
+async function generateJoinTicket(intent) {
+  const ttlSeconds = getJoinTicketTtlSeconds();
+  const payload = buildJoinTicketPayload(intent);
+  const token = signJoinTicket(payload, ttlSeconds);
+  const expiresAt = new Date(Date.now() + ttlSeconds * 1000);
+
+  const { intents } = await getCollections();
+  await intents.updateOne(
+    { intentId: intent.intentId },
+    {
+      $set: {
+        joinTicket: token,
+        joinTicketExpiresAt: expiresAt,
+        updatedAt: new Date()
+      }
+    }
+  );
+
+  return { token, expiresAt };
+}
+
+function parseMemoFromInstruction(instructions) {
+  const memoIx = instructions.find((ix) => ix.program === 'spl-memo' || ix.programId?.toBase58?.() === MEMO_PROGRAM_ID);
+  if (!memoIx) {
+    return null;
+  }
+  const memoText = extractMemoText(memoIx);
+  return memoText ? safeJsonParse(memoText) : null;
+}
+
+function instructionsContainTransfer(instructions, intent) {
+  const transferIx = instructions.find((ix) => ix.program === 'system' && ix.parsed?.type === 'transfer');
+  if (!transferIx) return { ok: false, reason: 'NO_TRANSFER' };
+  const info = transferIx.parsed.info;
+  if (info.destination !== intent.recipient) {
+    return { ok: false, reason: 'BAD_DESTINATION', expected: intent.recipient, received: info.destination };
+  }
+  if (Number(info.lamports) !== Number(intent.lamports)) {
+    return { ok: false, reason: 'BAD_AMOUNT', expected: intent.lamports, received: info.lamports };
+  }
+  if (info.source !== intent.playerPubkey) {
+    return { ok: false, reason: 'BAD_SOURCE', expected: intent.playerPubkey, received: info.source };
+  }
+  return { ok: true, instruction: transferIx };
+}
+
+export async function verifyIntent(intent) {
+  if (!intent.signature) {
+    return { status: intent.status, reason: 'NO_SIGNATURE' };
+  }
+
+  try {
+    const parsedTx = await getParsedTransactionWithRetries(intent.signature, { retries: 3 });
+    if (!parsedTx) {
+      return { status: intent.status, reason: 'PENDING' };
+    }
+
+    if (parsedTx.meta?.err) {
+      return { status: PaymentIntentStatus.MISMATCH, reason: 'TRANSACTION_ERROR', details: parsedTx.meta.err };
+    }
+
+    const memoJson = parseMemoFromInstruction(parsedTx.transaction.message.instructions);
+    if (!validateMemoAgainstIntent(intent, memoJson)) {
+      return { status: PaymentIntentStatus.MISMATCH, reason: 'MEMO_MISMATCH' };
+    }
+
+    const transferCheck = instructionsContainTransfer(parsedTx.transaction.message.instructions, intent);
+    if (!transferCheck.ok) {
+      return { status: PaymentIntentStatus.MISMATCH, reason: transferCheck.reason };
+    }
+
+    const rawTx = await getRawTransactionWithRetries(intent.signature, { retries: 3 });
+    const rawTxBase64 = rawTx ? Buffer.from(rawTx.transaction.serialize()).toString('base64') : null;
+
+    await recordTxAudit({ intent, signature: intent.signature, parsedTx, rawTxBase64 });
+
+    const { intents } = await getCollections();
+    const confirmedAt = new Date();
+
+    const updateResult = await intents.findOneAndUpdate(
+      { intentId: intent.intentId },
+      {
+        $set: {
+          status: PaymentIntentStatus.CONFIRMED,
+          confirmedAt,
+          updatedAt: confirmedAt,
+          memoJson
+        }
+      },
+      { returnDocument: 'after' }
+    );
+
+    const confirmedIntent = updateResult.value;
+    const joinTicket = await generateJoinTicket(confirmedIntent);
+
+    return { status: PaymentIntentStatus.CONFIRMED, joinTicket };
+  } catch (error) {
+    if (error?.message?.includes('BlockhashNotFound')) {
+      clearBlockhashCache();
+    }
+    console.error(`❌ Failed to verify intent ${intent.intentId}:`, error);
+    return { status: PaymentIntentStatus.MISMATCH, reason: error.message };
+  }
+}
+
+export async function verifyIntentById(intentId) {
+  const intent = await getIntentById(intentId);
+  if (!intent) {
+    return { status: 'NOT_FOUND' };
+  }
+  if (![PaymentIntentStatus.SENT, PaymentIntentStatus.MISMATCH].includes(intent.status)) {
+    return { status: intent.status };
+  }
+  return verifyIntent(intent);
+}
+
+export async function verifyPendingIntents(limit = 10) {
+  await ensureIndexes();
+  const { intents } = await getCollections();
+  const now = new Date();
+  const pending = await intents
+    .find({
+      status: { $in: [PaymentIntentStatus.SENT, PaymentIntentStatus.MISMATCH] },
+      expiresAt: { $gt: now }
+    })
+    .limit(limit)
+    .toArray();
+
+  const results = [];
+  for (const intent of pending) {
+    // eslint-disable-next-line no-await-in-loop
+    results.push(await verifyIntent(intent));
+  }
+  return results;
+}
+
+export async function expireStaleIntents() {
+  await ensureIndexes();
+  const { intents } = await getCollections();
+  const now = new Date();
+  const result = await intents.updateMany(
+    {
+      status: { $in: [PaymentIntentStatus.CREATED, PaymentIntentStatus.SENT, PaymentIntentStatus.MISMATCH] },
+      expiresAt: { $lt: now }
+    },
+    {
+      $set: {
+        status: PaymentIntentStatus.EXPIRED,
+        expiredAt: now,
+        updatedAt: now
+      }
+    }
+  );
+  return result.modifiedCount || 0;
+}
+
+export async function getJoinTicketForIntent(intentId) {
+  const intent = await getIntentById(intentId);
+  if (!intent) {
+    return null;
+  }
+
+  if (intent.status !== PaymentIntentStatus.CONFIRMED) {
+    return {
+      status: intent.status,
+      intent
+    };
+  }
+
+  const now = new Date();
+  if (!intent.joinTicket || !intent.joinTicketExpiresAt || intent.joinTicketExpiresAt < now) {
+    const joinTicket = await generateJoinTicket(intent);
+    return {
+      status: PaymentIntentStatus.CONFIRMED,
+      joinTicket
+    };
+  }
+
+  return {
+    status: PaymentIntentStatus.CONFIRMED,
+    joinTicket: {
+      token: intent.joinTicket,
+      expiresAt: intent.joinTicketExpiresAt
+    }
+  };
+}
+
+export async function markIntentConsumed(intentId) {
+  const { intents } = await getCollections();
+  const now = new Date();
+  const result = await intents.updateOne(
+    { intentId },
+    {
+      $set: {
+        status: PaymentIntentStatus.CONSUMED,
+        consumedAt: now,
+        updatedAt: now
+      }
+    }
+  );
+  return result.modifiedCount > 0;
+}
+
+export async function verifyJoinTicket(token) {
+  if (!JOIN_TICKET_SECRET) {
+    throw new Error('Join ticket secret not configured');
+  }
+  const decoded = jwt.verify(token, JOIN_TICKET_SECRET, {
+    issuer: JWT_ISSUER
+  });
+  return decoded;
+}
+
+export function getRateLimitKey(request, userId) {
+  const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || request.ip || 'unknown';
+  return `${ip}:${userId}`;
+}
+
+export { PaymentIntentStatus };

--- a/lib/paid/watchers.js
+++ b/lib/paid/watchers.js
@@ -1,0 +1,69 @@
+import {
+  expireStaleIntents,
+  verifyIntentById,
+  verifyPendingIntents
+} from './intentService.js';
+import { PaymentIntentStatus } from './constants.js';
+
+let watchersStarted = false;
+const activeVerifications = new Set();
+
+function schedule(fn, delay = 0) {
+  const timer = setTimeout(fn, delay);
+  if (typeof timer.unref === 'function') {
+    timer.unref();
+  }
+  return timer;
+}
+
+async function runPendingVerifications() {
+  try {
+    await verifyPendingIntents();
+  } catch (error) {
+    console.error('❌ Paid room verification sweep failed:', error);
+  }
+}
+
+async function runExpirySweep() {
+  try {
+    const expired = await expireStaleIntents();
+    if (expired > 0) {
+      console.log(`⏳ Expired ${expired} stale payment intents`);
+    }
+  } catch (error) {
+    console.error('❌ Paid room expiry sweep failed:', error);
+  }
+}
+
+export function ensurePaidRoomWatchers() {
+  if (watchersStarted) return;
+  watchersStarted = true;
+  schedule(runPendingVerifications, 3_000);
+  const verificationInterval = setInterval(runPendingVerifications, 5_000);
+  verificationInterval.unref?.();
+  const expiryInterval = setInterval(runExpirySweep, 10_000);
+  expiryInterval.unref?.();
+}
+
+export function scheduleIntentVerification(intentId, delay = 500) {
+  ensurePaidRoomWatchers();
+  if (activeVerifications.has(intentId)) {
+    return;
+  }
+  activeVerifications.add(intentId);
+  schedule(async () => {
+    try {
+      const result = await verifyIntentById(intentId);
+      if (result.status === PaymentIntentStatus.SENT) {
+        // Requeue to check again until confirmation or expiry
+        activeVerifications.delete(intentId);
+        scheduleIntentVerification(intentId, 3_000);
+        return;
+      }
+    } catch (error) {
+      console.error(`❌ Failed to verify intent ${intentId}:`, error);
+    } finally {
+      activeVerifications.delete(intentId);
+    }
+  }, delay);
+}

--- a/lib/solana.js
+++ b/lib/solana.js
@@ -1,95 +1,189 @@
 // Solana blockchain integration utilities
-import { Connection, PublicKey, LAMPORTS_PER_SOL, Transaction, SystemProgram } from '@solana/web3.js'
-import { TOKEN_PROGRAM_ID } from '@solana/spl-token'
+import {
+  Connection,
+  PublicKey,
+  LAMPORTS_PER_SOL,
+  Transaction,
+  SystemProgram,
+  ComputeBudgetProgram
+} from '@solana/web3.js';
+import { TOKEN_PROGRAM_ID } from '@solana/spl-token';
 
-const SOLANA_RPC_URL = process.env.NEXT_PUBLIC_SOLANA_NETWORK === 'mainnet-beta' 
-  ? 'https://api.mainnet-beta.solana.com'
-  : 'https://api.devnet.solana.com'
+export const MEMO_PROGRAM_ID = 'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr';
 
-const connection = new Connection(SOLANA_RPC_URL, 'confirmed')
+const SOLANA_RPC_URL = process.env.SOLANA_RPC_URL || (
+  process.env.NEXT_PUBLIC_SOLANA_NETWORK === 'mainnet-beta'
+    ? 'https://api.mainnet-beta.solana.com'
+    : 'https://api.devnet.solana.com'
+);
+
+const connection = new Connection(SOLANA_RPC_URL, {
+  commitment: 'confirmed',
+  disableRetryOnRateLimit: false
+});
+
+let cachedBlockhash = null;
+let cachedBlockhashFetchedAt = 0;
+const BLOCKHASH_TTL_MS = Number(process.env.PAID_ROOMS_BLOCKHASH_TTL_MS || 25_000);
+
+function isBlockhashStale() {
+  if (!cachedBlockhash) return true;
+  const now = Date.now();
+  return now - cachedBlockhashFetchedAt > BLOCKHASH_TTL_MS;
+}
+
+export async function getLatestBlockhashWithCache(force = false) {
+  if (!force && !isBlockhashStale()) {
+    return cachedBlockhash;
+  }
+
+  try {
+    const blockhashInfo = await connection.getLatestBlockhash();
+    cachedBlockhash = blockhashInfo;
+    cachedBlockhashFetchedAt = Date.now();
+    return blockhashInfo;
+  } catch (error) {
+    console.error('❌ Failed to fetch latest blockhash:', error);
+    if (!force && cachedBlockhash) {
+      return cachedBlockhash;
+    }
+    throw error;
+  }
+}
+
+export function clearBlockhashCache() {
+  cachedBlockhash = null;
+  cachedBlockhashFetchedAt = 0;
+}
+
+// Utility to create a compute budget instruction with priority fee
+export function buildPriorityFeeInstruction(microLamports) {
+  const priorityFee = Number(microLamports || 5_000);
+  return ComputeBudgetProgram.setComputeUnitPrice({ microLamports: priorityFee });
+}
 
 // Get SOL balance for a wallet address
 export async function getSolBalance(walletAddress) {
   try {
-    const publicKey = new PublicKey(walletAddress)
-    const balance = await connection.getBalance(publicKey)
-    return balance / LAMPORTS_PER_SOL
+    const publicKey = new PublicKey(walletAddress);
+    const balance = await connection.getBalance(publicKey);
+    return balance / LAMPORTS_PER_SOL;
   } catch (error) {
-    console.error('Error fetching SOL balance:', error)
-    throw new Error('Failed to fetch SOL balance')
+    console.error('Error fetching SOL balance:', error);
+    throw new Error('Failed to fetch SOL balance');
   }
 }
 
 // Get token accounts for a wallet (for other SPL tokens)
 export async function getTokenAccounts(walletAddress) {
   try {
-    const publicKey = new PublicKey(walletAddress)
+    const publicKey = new PublicKey(walletAddress);
     const tokenAccounts = await connection.getParsedTokenAccountsByOwner(
       publicKey,
       { programId: TOKEN_PROGRAM_ID }
-    )
-    
-    return tokenAccounts.value.map(account => ({
+    );
+
+    return tokenAccounts.value.map((account) => ({
       mint: account.account.data.parsed.info.mint,
       amount: account.account.data.parsed.info.tokenAmount.uiAmount,
       decimals: account.account.data.parsed.info.tokenAmount.decimals
-    }))
+    }));
   } catch (error) {
-    console.error('Error fetching token accounts:', error)
-    return []
+    console.error('Error fetching token accounts:', error);
+    return [];
   }
 }
 
 // Verify wallet signature (for authentication)
 export async function verifyWalletSignature(publicKey, signature, message) {
   try {
-    const publicKeyObj = new PublicKey(publicKey)
-    const messageBytes = new TextEncoder().encode(message)
-    const signatureBytes = new Uint8Array(signature.match(/.{1,2}/g).map(byte => parseInt(byte, 16)))
-    
+    const publicKeyObj = new PublicKey(publicKey);
+    const messageBytes = new TextEncoder().encode(message);
+    const signatureBytes = new Uint8Array(signature.match(/.{1,2}/g).map((byte) => parseInt(byte, 16)));
+
     // Note: This is a simplified verification - in production, use proper signature verification
-    return true // Placeholder for now
+    void publicKeyObj; // avoid lint warning
+    void messageBytes;
+    void signatureBytes;
+    return true; // Placeholder for now
   } catch (error) {
-    console.error('Error verifying signature:', error)
-    return false
+    console.error('Error verifying signature:', error);
+    return false;
   }
 }
 
 // Create transaction for game payout
 export async function createPayoutTransaction(fromWallet, toWallet, amount) {
   try {
-    const fromPublicKey = new PublicKey(fromWallet)
-    const toPublicKey = new PublicKey(toWallet)
-    const lamports = amount * LAMPORTS_PER_SOL
-    
+    const fromPublicKey = new PublicKey(fromWallet);
+    const toPublicKey = new PublicKey(toWallet);
+    const lamports = amount * LAMPORTS_PER_SOL;
+
     const transaction = new Transaction().add(
       SystemProgram.transfer({
         fromPubkey: fromPublicKey,
         toPubkey: toPublicKey,
-        lamports: lamports,
+        lamports
       })
-    )
-    
-    const { blockhash } = await connection.getLatestBlockhash()
-    transaction.recentBlockhash = blockhash
-    transaction.feePayer = fromPublicKey
-    
-    return transaction
+    );
+
+    const { blockhash } = await connection.getLatestBlockhash();
+    transaction.recentBlockhash = blockhash;
+    transaction.feePayer = fromPublicKey;
+
+    return transaction;
   } catch (error) {
-    console.error('Error creating payout transaction:', error)
-    throw new Error('Failed to create payout transaction')
+    console.error('Error creating payout transaction:', error);
+    throw new Error('Failed to create payout transaction');
   }
 }
 
 // Get transaction status
 export async function getTransactionStatus(signature) {
   try {
-    const status = await connection.getSignatureStatus(signature)
-    return status.value
+    const status = await connection.getSignatureStatus(signature);
+    return status.value;
   } catch (error) {
-    console.error('Error getting transaction status:', error)
-    return null
+    console.error('Error getting transaction status:', error);
+    return null;
   }
 }
 
-export { connection }
+async function withRetries(fn, { retries = 5, delayMs = 1_000 } = {}) {
+  let attempt = 0;
+  while (attempt <= retries) {
+    try {
+      return await fn();
+    } catch (error) {
+      attempt += 1;
+      if (attempt > retries) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, delayMs * attempt));
+    }
+  }
+}
+
+export async function getParsedTransactionWithRetries(signature, options = {}) {
+  return withRetries(
+    () =>
+      connection.getParsedTransaction(signature, {
+        commitment: 'confirmed',
+        maxSupportedTransactionVersion: 0
+      }),
+    options
+  );
+}
+
+export async function getRawTransactionWithRetries(signature, options = {}) {
+  return withRetries(
+    () =>
+      connection.getTransaction(signature, {
+        commitment: 'confirmed',
+        maxSupportedTransactionVersion: 0
+      }),
+    options
+  );
+}
+
+export { connection, PublicKey, SystemProgram };


### PR DESCRIPTION
## Summary
- add backend paid room endpoints for intent creation, signature submission, join ticket polling, and pricing quotes with rate limiting
- implement payment intent orchestration service with Mongo-backed storage, Solana transaction composition, confirmation audits, and join-ticket issuance
- introduce watcher utilities and Solana helpers for cached blockhashes, priority fees, and transaction retrieval while updating .gitignore to allow paid modules

## Testing
- npm run lint *(fails: repository already contains numerous lint errors in unrelated legacy pages and components)*

------
https://chatgpt.com/codex/tasks/task_e_68e48d2859448330a15c536af902a3c8