### PR TITLE
Add Helius RPC support for paid room transactions

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -50,7 +50,9 @@ export default function TurfLootTactical() {
         network: process.env.NEXT_PUBLIC_SOLANA_NETWORK || 'mainnet-beta',
         primary: process.env.NEXT_PUBLIC_SOLANA_RPC,
         list: process.env.NEXT_PUBLIC_SOLANA_RPC_LIST,
-        fallbacks: process.env.NEXT_PUBLIC_SOLANA_RPC_FALLBACKS
+        fallbacks: process.env.NEXT_PUBLIC_SOLANA_RPC_FALLBACKS,
+        heliusRpcUrl: process.env.NEXT_PUBLIC_HELIUS_RPC || process.env.HELIUS_RPC_URL,
+        heliusApiKey: process.env.NEXT_PUBLIC_HELIUS_API_KEY || process.env.HELIUS_API_KEY
       }),
     []
   )

--- a/frontend/app/page.js
+++ b/frontend/app/page.js
@@ -50,7 +50,9 @@ export default function TurfLootTactical() {
         network: process.env.NEXT_PUBLIC_SOLANA_NETWORK || 'mainnet-beta',
         primary: process.env.NEXT_PUBLIC_SOLANA_RPC,
         list: process.env.NEXT_PUBLIC_SOLANA_RPC_LIST,
-        fallbacks: process.env.NEXT_PUBLIC_SOLANA_RPC_FALLBACKS
+        fallbacks: process.env.NEXT_PUBLIC_SOLANA_RPC_FALLBACKS,
+        heliusRpcUrl: process.env.NEXT_PUBLIC_HELIUS_RPC || process.env.HELIUS_RPC_URL,
+        heliusApiKey: process.env.NEXT_PUBLIC_HELIUS_API_KEY || process.env.HELIUS_API_KEY
       }),
     []
   )

--- a/lib/paid/feeManager.js
+++ b/lib/paid/feeManager.js
@@ -40,13 +40,54 @@ const normaliseList = (value) =>
     .map((entry) => entry.trim())
     .filter(Boolean)
 
+const resolveEnv = (key) => {
+  if (typeof process === 'undefined') {
+    return undefined
+  }
+  return process?.env?.[key]
+}
+
+const normaliseHeliusNetwork = (network) => {
+  if (!network) {
+    return 'mainnet'
+  }
+
+  const trimmed = network.trim().toLowerCase()
+
+  if (trimmed === 'mainnet-beta' || trimmed === 'mainnet') {
+    return 'mainnet'
+  }
+  if (trimmed === 'devnet') {
+    return 'devnet'
+  }
+  if (trimmed === 'testnet') {
+    return 'testnet'
+  }
+
+  return trimmed
+}
+
 export const buildSolanaRpcEndpointList = ({
   network = 'mainnet-beta',
   primary,
   list = '',
-  fallbacks = ''
+  fallbacks = '',
+  heliusApiKey,
+  heliusRpcUrl
 } = {}) => {
   const endpoints = []
+
+  const envHeliusRpcUrl = heliusRpcUrl || resolveEnv('NEXT_PUBLIC_HELIUS_RPC_URL') || resolveEnv('HELIUS_RPC_URL')
+  const envHeliusApiKey = heliusApiKey || resolveEnv('NEXT_PUBLIC_HELIUS_API_KEY') || resolveEnv('HELIUS_API_KEY')
+
+  if (envHeliusRpcUrl) {
+    endpoints.push(envHeliusRpcUrl.trim())
+  } else if (envHeliusApiKey) {
+    const heliusNetwork = normaliseHeliusNetwork(network)
+    const heliusEndpoint = `https://${heliusNetwork}.helius-rpc.com/?api-key=${envHeliusApiKey.trim()}`
+    endpoints.push(heliusEndpoint)
+  }
+
   if (primary) {
     endpoints.push(primary.trim())
   }


### PR DESCRIPTION
## Summary
- update the Solana RPC builder to prefer configured Helius endpoints or API keys when available
- pass Helius environment values from the app pages so paid room fee deductions use the paid RPC first

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4a016c01c8330a5cea72e68a9ebf8