### PR TITLE
Handle Solana wallets without direct sendTransaction support

### DIFF
--- a/lib/paid/feeManager.js
+++ b/lib/paid/feeManager.js
@@ -121,46 +121,157 @@ export const buildSolanaRpcEndpointList = ({
   )
 }
 
-const selectSendTransaction = (solanaWallet, privyUser) => {
+const bindHandler = (fn, context) => (typeof fn === 'function' ? fn.bind(context) : null)
+
+const callWithOptionalArgs = (handler, transaction, connection, options) => {
+  if (typeof handler !== 'function') {
+    throw new Error('Invalid Solana transaction handler provided.')
+  }
+
+  const expectedArgs = Number.isInteger(handler.length) ? handler.length : 0
+
+  if (expectedArgs >= 3) {
+    return handler(transaction, connection, options)
+  }
+  if (expectedArgs === 2) {
+    return handler(transaction, connection)
+  }
+
+  return handler(transaction)
+}
+
+const selectSendTransaction = async (solanaWallet, privyUser) => {
   if (!solanaWallet) {
     return null
   }
 
-  const candidates = [
-    solanaWallet.sendTransaction,
-    solanaWallet.signAndSendTransaction,
-    solanaWallet?.walletClient?.solana?.sendTransaction,
-    solanaWallet?.walletClient?.solana?.signAndSendTransaction
+  const sendCandidates = [
+    bindHandler(solanaWallet.sendTransaction, solanaWallet),
+    bindHandler(solanaWallet.signAndSendTransaction, solanaWallet),
+    bindHandler(solanaWallet?.walletClient?.solana?.sendTransaction, solanaWallet?.walletClient?.solana),
+    bindHandler(solanaWallet?.walletClient?.solana?.signAndSendTransaction, solanaWallet?.walletClient?.solana)
   ]
 
-  for (const fn of candidates) {
-    if (typeof fn === 'function') {
-      return fn.bind(fn === solanaWallet?.walletClient?.solana?.sendTransaction || fn === solanaWallet?.walletClient?.solana?.signAndSendTransaction ? solanaWallet.walletClient.solana : solanaWallet)
+  for (const candidate of sendCandidates) {
+    if (candidate) {
+      return { mode: 'send', handler: candidate }
+    }
+  }
+
+  const signCandidates = [
+    bindHandler(solanaWallet.signTransaction, solanaWallet),
+    bindHandler(solanaWallet?.walletClient?.solana?.signTransaction, solanaWallet?.walletClient?.solana),
+    bindHandler(privyUser?.wallet?.walletClient?.solana?.signTransaction, privyUser?.wallet?.walletClient?.solana)
+  ]
+
+  for (const candidate of signCandidates) {
+    if (candidate) {
+      return { mode: 'sign', handler: candidate }
     }
   }
 
   if (typeof solanaWallet.getProvider === 'function') {
-    return async (...args) => {
+    try {
       const provider = await solanaWallet.getProvider()
-      if (provider?.sendTransaction) {
-        return provider.sendTransaction(...args)
+      const providerSendCandidates = [
+        bindHandler(provider?.sendTransaction, provider),
+        bindHandler(provider?.signAndSendTransaction, provider)
+      ]
+
+      for (const candidate of providerSendCandidates) {
+        if (candidate) {
+          return { mode: 'send', handler: candidate }
+        }
       }
-      if (provider?.signAndSendTransaction) {
-        return provider.signAndSendTransaction(...args)
+
+      const providerSignCandidate = bindHandler(provider?.signTransaction, provider)
+      if (providerSignCandidate) {
+        return { mode: 'sign', handler: providerSignCandidate }
       }
-      throw new Error('Connected provider does not expose a transaction sender.')
+    } catch (error) {
+      console.warn('⚠️ Failed to resolve Solana provider from wallet:', error)
     }
   }
 
   if (privyUser?.wallet?.walletClient?.solana?.sendTransaction) {
-    return privyUser.wallet.walletClient.solana.sendTransaction.bind(privyUser.wallet.walletClient.solana)
+    return {
+      mode: 'send',
+      handler: privyUser.wallet.walletClient.solana.sendTransaction.bind(privyUser.wallet.walletClient.solana)
+    }
   }
 
   if (privyUser?.wallet?.walletClient?.solana?.signAndSendTransaction) {
-    return privyUser.wallet.walletClient.solana.signAndSendTransaction.bind(privyUser.wallet.walletClient.solana)
+    return {
+      mode: 'send',
+      handler: privyUser.wallet.walletClient.solana.signAndSendTransaction.bind(privyUser.wallet.walletClient.solana)
+    }
+  }
+
+  if (privyUser?.wallet?.walletClient?.solana?.signTransaction) {
+    return {
+      mode: 'sign',
+      handler: privyUser.wallet.walletClient.solana.signTransaction.bind(privyUser.wallet.walletClient.solana)
+    }
   }
 
   return null
+}
+
+const toUint8Array = (value) => {
+  if (!value) {
+    return null
+  }
+
+  if (value instanceof Uint8Array) {
+    return value
+  }
+
+  if (typeof Buffer !== 'undefined' && Buffer.isBuffer?.(value)) {
+    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength)
+  }
+
+  if (ArrayBuffer.isView(value)) {
+    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength)
+  }
+
+  if (value instanceof ArrayBuffer) {
+    return new Uint8Array(value)
+  }
+
+  if (Array.isArray(value)) {
+    return Uint8Array.from(value)
+  }
+
+  return null
+}
+
+const normaliseSignedTransaction = (signedResult) => {
+  if (!signedResult) {
+    throw new Error('Wallet did not return a signed transaction.')
+  }
+
+  const candidate =
+    signedResult?.signedTransaction || signedResult?.transaction || signedResult?.rawTransaction || signedResult
+
+  if (typeof candidate === 'string') {
+    return { signature: candidate }
+  }
+
+  if (candidate?.serialize) {
+    const serialised = candidate.serialize()
+    const raw = toUint8Array(serialised)
+    if (!raw) {
+      throw new Error('Unable to serialise signed transaction from wallet response.')
+    }
+    return { raw, transaction: candidate }
+  }
+
+  const rawCandidate = toUint8Array(candidate)
+  if (rawCandidate) {
+    return { raw: rawCandidate }
+  }
+
+  throw new Error('Wallet did not provide a serializable signed transaction.')
 }
 
 const connectToSolana = async (rpcEndpoints = []) => {
@@ -247,9 +358,9 @@ export const deductPaidRoomFee = async ({
   transaction.recentBlockhash = latestBlockhash.blockhash
   transaction.feePayer = fromPublicKey
 
-  const sendTransaction = selectSendTransaction(solanaWallet, privyUser)
+  const transactionHandler = await selectSendTransaction(solanaWallet, privyUser)
 
-  if (!sendTransaction) {
+  if (!transactionHandler || !transactionHandler.handler || !transactionHandler.mode) {
     throw new Error('Unable to access signing capabilities for the connected Solana wallet.')
   }
 
@@ -261,9 +372,55 @@ export const deductPaidRoomFee = async ({
     serverWallet: serverWalletAddress
   })
 
-  const signature = await sendTransaction(transaction, connection, {
-    preflightCommitment: 'confirmed'
-  })
+  let signature
+  let signedTransactionRaw
+
+  if (transactionHandler.mode === 'send') {
+    const sendResult = await callWithOptionalArgs(
+      transactionHandler.handler,
+      transaction,
+      connection,
+      { preflightCommitment: 'confirmed' }
+    )
+
+    if (typeof sendResult === 'string') {
+      signature = sendResult
+    } else if (sendResult?.signature) {
+      signature = sendResult.signature
+      signedTransactionRaw = sendResult?.rawTransaction
+    } else if (sendResult) {
+      if (typeof sendResult === 'object') {
+        throw new Error('Unexpected response from Solana wallet when sending transaction.')
+      }
+      signature = String(sendResult)
+    }
+  } else if (transactionHandler.mode === 'sign') {
+    const signedResult = await callWithOptionalArgs(transactionHandler.handler, transaction, connection, {
+      preflightCommitment: 'confirmed'
+    })
+
+    const { raw, signature: providedSignature } = normaliseSignedTransaction(signedResult)
+
+    if (providedSignature) {
+      signature = providedSignature
+    }
+
+    if (raw && !signedTransactionRaw) {
+      signedTransactionRaw = raw
+    }
+
+    if (!signature) {
+      signature = await connection.sendRawTransaction(raw, {
+        preflightCommitment: 'confirmed'
+      })
+    }
+  } else {
+    throw new Error('Unsupported Solana wallet signing mode encountered.')
+  }
+
+  if (!signature) {
+    throw new Error('Failed to obtain a Solana transaction signature from the wallet.')
+  }
 
   log.log?.('📝 Transaction submitted. Awaiting confirmation…', signature)
 
@@ -285,7 +442,8 @@ export const deductPaidRoomFee = async ({
     costs,
     rpcEndpoint: endpoint,
     walletAddress,
-    serverWallet: serverWalletAddress
+    serverWallet: serverWalletAddress,
+    rawTransaction: signedTransactionRaw
   }
 }
 


### PR DESCRIPTION
## Summary
- add flexible Solana wallet handler resolution so paid room fees can be processed by wallets that only expose signing helpers
- normalise signed transaction payloads and manually submit them when necessary
- tighten error handling and propagate raw transaction data for easier debugging of Solana transfers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4a23f09c483309b7baffbf3cc574b