### PR TITLE
Improve Solana wallet handler discovery

### DIFF
--- a/lib/paid/feeManager.js
+++ b/lib/paid/feeManager.js
@@ -140,16 +140,16 @@ const callWithOptionalArgs = (handler, transaction, connection, options) => {
   return handler(transaction)
 }
 
-const selectSendTransaction = async (solanaWallet, privyUser) => {
-  if (!solanaWallet) {
+const resolveHandlerFromSource = (source) => {
+  if (!source) {
     return null
   }
 
   const sendCandidates = [
-    bindHandler(solanaWallet.sendTransaction, solanaWallet),
-    bindHandler(solanaWallet.signAndSendTransaction, solanaWallet),
-    bindHandler(solanaWallet?.walletClient?.solana?.sendTransaction, solanaWallet?.walletClient?.solana),
-    bindHandler(solanaWallet?.walletClient?.solana?.signAndSendTransaction, solanaWallet?.walletClient?.solana)
+    bindHandler(source.sendTransaction, source),
+    bindHandler(source.signAndSendTransaction, source),
+    bindHandler(source?.solana?.sendTransaction, source?.solana),
+    bindHandler(source?.solana?.signAndSendTransaction, source?.solana)
   ]
 
   for (const candidate of sendCandidates) {
@@ -159,9 +159,8 @@ const selectSendTransaction = async (solanaWallet, privyUser) => {
   }
 
   const signCandidates = [
-    bindHandler(solanaWallet.signTransaction, solanaWallet),
-    bindHandler(solanaWallet?.walletClient?.solana?.signTransaction, solanaWallet?.walletClient?.solana),
-    bindHandler(privyUser?.wallet?.walletClient?.solana?.signTransaction, privyUser?.wallet?.walletClient?.solana)
+    bindHandler(source.signTransaction, source),
+    bindHandler(source?.solana?.signTransaction, source?.solana)
   ]
 
   for (const candidate of signCandidates) {
@@ -170,47 +169,110 @@ const selectSendTransaction = async (solanaWallet, privyUser) => {
     }
   }
 
-  if (typeof solanaWallet.getProvider === 'function') {
-    try {
-      const provider = await solanaWallet.getProvider()
-      const providerSendCandidates = [
-        bindHandler(provider?.sendTransaction, provider),
-        bindHandler(provider?.signAndSendTransaction, provider)
-      ]
+  return null
+}
 
-      for (const candidate of providerSendCandidates) {
-        if (candidate) {
-          return { mode: 'send', handler: candidate }
+const selectSendTransaction = async (solanaWallet, privyUser) => {
+  const checkedSources = new Set()
+  const queue = []
+
+  if (solanaWallet) {
+    queue.push(solanaWallet)
+
+    if (solanaWallet.walletClient) {
+      queue.push(solanaWallet.walletClient)
+    }
+
+    if (solanaWallet.walletClient?.solana) {
+      queue.push(solanaWallet.walletClient.solana)
+    }
+
+    if (solanaWallet.adapter) {
+      queue.push(solanaWallet.adapter)
+    }
+  }
+
+  if (typeof solanaWallet?.getWalletClient === 'function') {
+    try {
+      const client = await solanaWallet.getWalletClient()
+      if (client) {
+        queue.push(client)
+        if (client.solana) {
+          queue.push(client.solana)
         }
       }
+    } catch (error) {
+      console.warn('⚠️ Failed to resolve wallet client for Solana wallet:', error)
+    }
+  }
 
-      const providerSignCandidate = bindHandler(provider?.signTransaction, provider)
-      if (providerSignCandidate) {
-        return { mode: 'sign', handler: providerSignCandidate }
+  if (typeof solanaWallet?.getProvider === 'function') {
+    try {
+      const provider = await solanaWallet.getProvider()
+      if (provider) {
+        queue.push(provider)
       }
     } catch (error) {
       console.warn('⚠️ Failed to resolve Solana provider from wallet:', error)
     }
   }
 
-  if (privyUser?.wallet?.walletClient?.solana?.sendTransaction) {
-    return {
-      mode: 'send',
-      handler: privyUser.wallet.walletClient.solana.sendTransaction.bind(privyUser.wallet.walletClient.solana)
+  if (privyUser?.wallet) {
+    queue.push(privyUser.wallet)
+
+    if (privyUser.wallet.walletClient) {
+      queue.push(privyUser.wallet.walletClient)
+      if (privyUser.wallet.walletClient.solana) {
+        queue.push(privyUser.wallet.walletClient.solana)
+      }
+    }
+
+    if (typeof privyUser.wallet.getWalletClient === 'function') {
+      try {
+        const embeddedClient = await privyUser.wallet.getWalletClient()
+        if (embeddedClient) {
+          queue.push(embeddedClient)
+          if (embeddedClient.solana) {
+            queue.push(embeddedClient.solana)
+          }
+        }
+      } catch (error) {
+        console.warn('⚠️ Failed to resolve embedded wallet client:', error)
+      }
+    }
+
+    if (typeof privyUser.wallet.getProvider === 'function') {
+      try {
+        const embeddedProvider = await privyUser.wallet.getProvider()
+        if (embeddedProvider) {
+          queue.push(embeddedProvider)
+        }
+      } catch (error) {
+        console.warn('⚠️ Failed to resolve embedded wallet provider:', error)
+      }
     }
   }
 
-  if (privyUser?.wallet?.walletClient?.solana?.signAndSendTransaction) {
-    return {
-      mode: 'send',
-      handler: privyUser.wallet.walletClient.solana.signAndSendTransaction.bind(privyUser.wallet.walletClient.solana)
+  if (Array.isArray(privyUser?.linkedAccounts)) {
+    for (const account of privyUser.linkedAccounts) {
+      if (account?.walletClient) {
+        queue.push(account.walletClient)
+        if (account.walletClient.solana) {
+          queue.push(account.walletClient.solana)
+        }
+      }
     }
   }
 
-  if (privyUser?.wallet?.walletClient?.solana?.signTransaction) {
-    return {
-      mode: 'sign',
-      handler: privyUser.wallet.walletClient.solana.signTransaction.bind(privyUser.wallet.walletClient.solana)
+  for (const source of queue) {
+    if (!source || checkedSources.has(source)) {
+      continue
+    }
+    checkedSources.add(source)
+
+    const handler = resolveHandlerFromSource(source)
+    if (handler) {
+      return handler
     }
   }
 


### PR DESCRIPTION
## Summary
- broaden Solana wallet handler discovery to include additional Privy client and provider fallbacks
- reuse a common resolver helper to capture send and sign handlers across wallet sources
- improve logging when a client or provider cannot be obtained so paid room deductions have more context

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4a615d4e8833087b70b898535bbf5