### PR TITLE
Improve Solana wallet handler discovery for paid rooms

### DIFF
--- a/lib/paid/feeManager.js
+++ b/lib/paid/feeManager.js
@@ -123,6 +123,42 @@ export const buildSolanaRpcEndpointList = ({
 
 const bindHandler = (fn, context) => (typeof fn === 'function' ? fn.bind(context) : null)
 
+const collectSendCandidates = (source) =>
+  [
+    bindHandler(source?.sendTransaction, source),
+    bindHandler(source?.signAndSendTransaction, source),
+    bindHandler(source?.signAndSendSolanaTransaction, source),
+    bindHandler(source?.sendAndConfirmTransaction, source),
+    bindHandler(source?.signTransactionAndSend, source),
+    bindHandler(source?.solana?.sendTransaction, source?.solana),
+    bindHandler(source?.solana?.signAndSendTransaction, source?.solana),
+    bindHandler(source?.solana?.signAndSendSolanaTransaction, source?.solana),
+    bindHandler(source?.solana?.sendAndConfirmTransaction, source?.solana),
+    bindHandler(source?.wallet?.sendTransaction, source?.wallet),
+    bindHandler(source?.wallet?.signAndSendTransaction, source?.wallet),
+    bindHandler(source?.wallet?.sendAndConfirmTransaction, source?.wallet),
+    bindHandler(source?.provider?.sendTransaction, source?.provider),
+    bindHandler(source?.provider?.signAndSendTransaction, source?.provider),
+    bindHandler(source?.provider?.sendAndConfirmTransaction, source?.provider),
+    bindHandler(source?.adapter?.sendTransaction, source?.adapter),
+    bindHandler(source?.adapter?.signAndSendTransaction, source?.adapter),
+    bindHandler(source?.adapter?.sendAndConfirmTransaction, source?.adapter)
+  ].filter(Boolean)
+
+const collectSignCandidates = (source) =>
+  [
+    bindHandler(source?.signTransaction, source),
+    bindHandler(source?.signSolanaTransaction, source),
+    bindHandler(source?.solana?.signTransaction, source?.solana),
+    bindHandler(source?.solana?.signSolanaTransaction, source?.solana),
+    bindHandler(source?.wallet?.signTransaction, source?.wallet),
+    bindHandler(source?.wallet?.signSolanaTransaction, source?.wallet),
+    bindHandler(source?.provider?.signTransaction, source?.provider),
+    bindHandler(source?.provider?.signSolanaTransaction, source?.provider),
+    bindHandler(source?.adapter?.signTransaction, source?.adapter),
+    bindHandler(source?.adapter?.signSolanaTransaction, source?.adapter)
+  ].filter(Boolean)
+
 const callWithOptionalArgs = (handler, transaction, connection, options) => {
   if (typeof handler !== 'function') {
     throw new Error('Invalid Solana transaction handler provided.')
@@ -145,25 +181,13 @@ const resolveHandlerFromSource = (source) => {
     return null
   }
 
-  const sendCandidates = [
-    bindHandler(source.sendTransaction, source),
-    bindHandler(source.signAndSendTransaction, source),
-    bindHandler(source?.solana?.sendTransaction, source?.solana),
-    bindHandler(source?.solana?.signAndSendTransaction, source?.solana)
-  ]
-
-  for (const candidate of sendCandidates) {
+  for (const candidate of collectSendCandidates(source)) {
     if (candidate) {
       return { mode: 'send', handler: candidate }
     }
   }
 
-  const signCandidates = [
-    bindHandler(source.signTransaction, source),
-    bindHandler(source?.solana?.signTransaction, source?.solana)
-  ]
-
-  for (const candidate of signCandidates) {
+  for (const candidate of collectSignCandidates(source)) {
     if (candidate) {
       return { mode: 'sign', handler: candidate }
     }
@@ -175,20 +199,59 @@ const resolveHandlerFromSource = (source) => {
 const selectSendTransaction = async (solanaWallet, privyUser) => {
   const checkedSources = new Set()
   const queue = []
+  const queuedSources = new WeakSet()
+
+  const enqueue = (candidate) => {
+    if (!candidate || (typeof candidate === 'object' && candidate !== null && queuedSources.has(candidate))) {
+      return
+    }
+
+    if (typeof candidate === 'object' && candidate !== null) {
+      queuedSources.add(candidate)
+    }
+
+    queue.push(candidate)
+
+    const nestedCandidates = []
+
+    if (candidate?.solana) {
+      nestedCandidates.push(candidate.solana)
+    }
+
+    if (candidate?.wallet) {
+      nestedCandidates.push(candidate.wallet)
+    }
+
+    if (candidate?.provider) {
+      nestedCandidates.push(candidate.provider)
+    }
+
+    if (candidate?.adapter) {
+      nestedCandidates.push(candidate.adapter)
+    }
+
+    if (Array.isArray(candidate?.providers)) {
+      nestedCandidates.push(...candidate.providers.filter(Boolean))
+    }
+
+    for (const nested of nestedCandidates) {
+      enqueue(nested)
+    }
+  }
 
   if (solanaWallet) {
-    queue.push(solanaWallet)
+    enqueue(solanaWallet)
 
     if (solanaWallet.walletClient) {
-      queue.push(solanaWallet.walletClient)
+      enqueue(solanaWallet.walletClient)
     }
 
     if (solanaWallet.walletClient?.solana) {
-      queue.push(solanaWallet.walletClient.solana)
+      enqueue(solanaWallet.walletClient.solana)
     }
 
     if (solanaWallet.adapter) {
-      queue.push(solanaWallet.adapter)
+      enqueue(solanaWallet.adapter)
     }
   }
 
@@ -196,10 +259,7 @@ const selectSendTransaction = async (solanaWallet, privyUser) => {
     try {
       const client = await solanaWallet.getWalletClient()
       if (client) {
-        queue.push(client)
-        if (client.solana) {
-          queue.push(client.solana)
-        }
+        enqueue(client)
       }
     } catch (error) {
       console.warn('⚠️ Failed to resolve wallet client for Solana wallet:', error)
@@ -210,7 +270,7 @@ const selectSendTransaction = async (solanaWallet, privyUser) => {
     try {
       const provider = await solanaWallet.getProvider()
       if (provider) {
-        queue.push(provider)
+        enqueue(provider)
       }
     } catch (error) {
       console.warn('⚠️ Failed to resolve Solana provider from wallet:', error)
@@ -218,23 +278,17 @@ const selectSendTransaction = async (solanaWallet, privyUser) => {
   }
 
   if (privyUser?.wallet) {
-    queue.push(privyUser.wallet)
+    enqueue(privyUser.wallet)
 
     if (privyUser.wallet.walletClient) {
-      queue.push(privyUser.wallet.walletClient)
-      if (privyUser.wallet.walletClient.solana) {
-        queue.push(privyUser.wallet.walletClient.solana)
-      }
+      enqueue(privyUser.wallet.walletClient)
     }
 
     if (typeof privyUser.wallet.getWalletClient === 'function') {
       try {
         const embeddedClient = await privyUser.wallet.getWalletClient()
         if (embeddedClient) {
-          queue.push(embeddedClient)
-          if (embeddedClient.solana) {
-            queue.push(embeddedClient.solana)
-          }
+          enqueue(embeddedClient)
         }
       } catch (error) {
         console.warn('⚠️ Failed to resolve embedded wallet client:', error)
@@ -245,7 +299,7 @@ const selectSendTransaction = async (solanaWallet, privyUser) => {
       try {
         const embeddedProvider = await privyUser.wallet.getProvider()
         if (embeddedProvider) {
-          queue.push(embeddedProvider)
+          enqueue(embeddedProvider)
         }
       } catch (error) {
         console.warn('⚠️ Failed to resolve embedded wallet provider:', error)
@@ -255,10 +309,31 @@ const selectSendTransaction = async (solanaWallet, privyUser) => {
 
   if (Array.isArray(privyUser?.linkedAccounts)) {
     for (const account of privyUser.linkedAccounts) {
+      enqueue(account)
+
       if (account?.walletClient) {
-        queue.push(account.walletClient)
-        if (account.walletClient.solana) {
-          queue.push(account.walletClient.solana)
+        enqueue(account.walletClient)
+      }
+
+      if (typeof account?.getWalletClient === 'function') {
+        try {
+          const linkedClient = await account.getWalletClient()
+          if (linkedClient) {
+            enqueue(linkedClient)
+          }
+        } catch (error) {
+          console.warn('⚠️ Failed to resolve linked account wallet client:', error)
+        }
+      }
+
+      if (typeof account?.getProvider === 'function') {
+        try {
+          const linkedProvider = await account.getProvider()
+          if (linkedProvider) {
+            enqueue(linkedProvider)
+          }
+        } catch (error) {
+          console.warn('⚠️ Failed to resolve linked account provider:', error)
         }
       }
     }


### PR DESCRIPTION
## Summary
- expand the Solana wallet handler detection to cover additional provider shapes exposed by Privy wallets
- recursively inspect nested provider objects when resolving send/sign transaction functions so paid room deductions can access signing capabilities

## Testing
- node -c lib/paid/feeManager.js

------
https://chatgpt.com/codex/tasks/task_e_68e4a8fa6a4483309a4e73d90f3dc8e4