### PR TITLE
Expand Solana wallet detection for fee deductions

### DIFF
--- a/lib/paid/feeManager.js
+++ b/lib/paid/feeManager.js
@@ -123,6 +123,63 @@ export const buildSolanaRpcEndpointList = ({
 
 const bindHandler = (fn, context) => (typeof fn === 'function' ? fn.bind(context) : null)
 
+const getGlobalObject = () => {
+  if (typeof globalThis !== 'undefined') {
+    return globalThis
+  }
+  if (typeof window !== 'undefined') {
+    return window
+  }
+  if (typeof self !== 'undefined') {
+    return self
+  }
+  return undefined
+}
+
+const collectGlobalSolanaProviders = () => {
+  const candidates = []
+  const seen = new Set()
+  const push = (provider) => {
+    if (provider && !seen.has(provider)) {
+      seen.add(provider)
+      candidates.push(provider)
+    }
+  }
+
+  const globalObj = getGlobalObject()
+  if (!globalObj) {
+    return candidates
+  }
+
+  const directCandidates = [
+    globalObj.solana,
+    globalObj.phantom?.solana,
+    globalObj.backpack?.solana,
+    globalObj.glow?.solana,
+    globalObj.solflare?.solana,
+    globalObj.slope?.solana,
+    globalObj.sollet?.solana || globalObj.sollet
+  ]
+
+  for (const direct of directCandidates) {
+    push(direct)
+  }
+
+  const providerCollections = [
+    Array.isArray(globalObj.solana?.providers) ? globalObj.solana.providers : [],
+    Array.isArray(globalObj.solanaProviders) ? globalObj.solanaProviders : [],
+    Array.isArray(globalObj.phantom?.providers) ? globalObj.phantom.providers : []
+  ]
+
+  for (const collection of providerCollections) {
+    for (const provider of collection) {
+      push(provider)
+    }
+  }
+
+  return candidates
+}
+
 const collectSendCandidates = (source) =>
   [
     bindHandler(source?.sendTransaction, source),
@@ -336,6 +393,18 @@ const selectSendTransaction = async (solanaWallet, privyUser) => {
           console.warn('⚠️ Failed to resolve linked account provider:', error)
         }
       }
+    }
+  }
+
+  for (const browserProvider of collectGlobalSolanaProviders()) {
+    enqueue(browserProvider)
+
+    if (browserProvider?.provider) {
+      enqueue(browserProvider.provider)
+    }
+
+    if (browserProvider?.wallet) {
+      enqueue(browserProvider.wallet)
     }
   }
 


### PR DESCRIPTION
## Summary
- add global Solana provider discovery so fee deductions can use browser wallet adapters
- enqueue detected browser providers to resolve available send/sign handlers during fee processing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4ab4dd27883309e88cb3508e9fba4