### PR TITLE
Fix paid room Solana signing via Privy hooks

### DIFF
--- a/frontend/app/page.js
+++ b/frontend/app/page.js
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import { usePrivy, useWallets, useFundWallet } from '@privy-io/react-auth'
+import { useSignAndSendTransaction, useSignTransaction } from '@privy-io/react-auth/solana'
 import { buildSolanaRpcEndpointList, calculatePaidRoomCosts, deductPaidRoomFee, SERVER_WALLET_ADDRESS } from '../../lib/paid/feeManager'
 // NOTE: Should be '@privy-io/react-auth/solana' per docs, but causes compatibility issues
 import ServerBrowserModal from '../components/ServerBrowserModalNew'
@@ -14,6 +15,8 @@ export default function TurfLootTactical() {
   const { ready, authenticated, user: privyUser, login, logout } = usePrivy()
   const { wallets } = useWallets()
   const { fundWallet } = useFundWallet()
+  const { signAndSendTransaction: privySignAndSendTransaction } = useSignAndSendTransaction()
+  const { signTransaction: privySignTransaction } = useSignTransaction()
   
   // LOYALTY SYSTEM STATE
   const [loyaltyData, setLoyaltyData] = useState(null)
@@ -57,6 +60,19 @@ export default function TurfLootTactical() {
     []
   )
   const USD_PER_SOL_FALLBACK = parseFloat(process.env.NEXT_PUBLIC_USD_PER_SOL || '150')
+  const SOLANA_CHAIN = useMemo(() => {
+    const network = (process.env.NEXT_PUBLIC_SOLANA_NETWORK || 'mainnet-beta').toLowerCase()
+    if (network.startsWith('solana:')) {
+      return network
+    }
+    if (network === 'devnet') {
+      return 'solana:devnet'
+    }
+    if (network === 'testnet') {
+      return 'solana:testnet'
+    }
+    return 'solana:mainnet'
+  }, [])
 
   const resolveSolanaWallet = () => {
     if (wallets && wallets.length > 0) {
@@ -131,7 +147,10 @@ export default function TurfLootTactical() {
         rpcEndpoints: SOLANA_RPC_ENDPOINTS,
         usdPerSolFallback: USD_PER_SOL_FALLBACK,
         serverWalletAddress: SERVER_WALLET_ADDRESS,
-        logger: console
+        logger: console,
+        signAndSendTransactionFn: privySignAndSendTransaction,
+        signTransactionFn: privySignTransaction,
+        solanaChain: SOLANA_CHAIN
       })
 
       const resultCosts = deductionResult.costs || costs

--- a/lib/paid/feeManager.js
+++ b/lib/paid/feeManager.js
@@ -1,4 +1,5 @@
 import { Connection, PublicKey, SystemProgram, Transaction, LAMPORTS_PER_SOL, clusterApiUrl } from '@solana/web3.js'
+import bs58 from 'bs58'
 
 export const SERVER_WALLET_ADDRESS = 'GrYLV9QSnkDwEQ3saypgM9LLHwE36QPZrYCRJceyQfTa'
 
@@ -423,6 +424,58 @@ const selectSendTransaction = async (solanaWallet, privyUser) => {
   return null
 }
 
+const deriveSolanaChainIdentifier = (chain) => {
+  if (!chain) {
+    return 'solana:mainnet'
+  }
+
+  const normalised = String(chain).trim().toLowerCase()
+
+  if (normalised.startsWith('solana:')) {
+    return normalised
+  }
+
+  if (normalised === 'mainnet' || normalised === 'mainnet-beta') {
+    return 'solana:mainnet'
+  }
+
+  if (normalised === 'devnet') {
+    return 'solana:devnet'
+  }
+
+  if (normalised === 'testnet') {
+    return 'solana:testnet'
+  }
+
+  return `solana:${normalised}`
+}
+
+const serialiseTransaction = (transaction) => {
+  try {
+    const raw = transaction.serialize({ requireAllSignatures: false, verifySignatures: false })
+    return toUint8Array(raw)
+  } catch (error) {
+    throw new Error(`Unable to serialise Solana transaction for signing: ${error?.message || error}`)
+  }
+}
+
+const normaliseSignature = (value) => {
+  if (!value) {
+    return null
+  }
+
+  if (typeof value === 'string') {
+    return value
+  }
+
+  const bytes = toUint8Array(value)
+  if (bytes) {
+    return bs58.encode(bytes)
+  }
+
+  return null
+}
+
 const toUint8Array = (value) => {
   if (!value) {
     return null
@@ -506,7 +559,10 @@ export const deductPaidRoomFee = async ({
   rpcEndpoints,
   usdPerSolFallback = DEFAULT_USD_PER_SOL,
   serverWalletAddress = SERVER_WALLET_ADDRESS,
-  logger = console
+  logger = console,
+  signAndSendTransactionFn,
+  signTransactionFn,
+  solanaChain
 }) => {
   const log = logger || console
   const costs = calculatePaidRoomCosts(entryFeeUsd, feePercentage)
@@ -553,93 +609,231 @@ export const deductPaidRoomFee = async ({
   const fromPublicKey = new PublicKey(walletAddress)
   const toPublicKey = new PublicKey(serverWalletAddress)
 
-  const transaction = new Transaction().add(
-    SystemProgram.transfer({
-      fromPubkey: fromPublicKey,
-      toPubkey: toPublicKey,
-      lamports
-    })
-  )
+  const buildTransaction = () => {
+    const tx = new Transaction().add(
+      SystemProgram.transfer({
+        fromPubkey: fromPublicKey,
+        toPubkey: toPublicKey,
+        lamports
+      })
+    )
 
-  transaction.recentBlockhash = latestBlockhash.blockhash
-  transaction.feePayer = fromPublicKey
+    tx.recentBlockhash = latestBlockhash.blockhash
+    tx.feePayer = fromPublicKey
 
-  const transactionHandler = await selectSendTransaction(solanaWallet, privyUser)
-
-  if (!transactionHandler || !transactionHandler.handler || !transactionHandler.mode) {
-    throw new Error('Unable to access signing capabilities for the connected Solana wallet.')
+    return tx
   }
 
-  log.log?.('🔄 Processing Solana transaction via Privy...', {
-    lamports,
-    totalCostSol,
-    usdPerSol,
-    walletAddress,
-    serverWallet: serverWalletAddress
-  })
+  const chainIdentifier = deriveSolanaChainIdentifier(solanaChain)
+  const preflightOptions = { preflightCommitment: 'confirmed' }
 
   let signature
   let signedTransactionRaw
+  let signingMode
+  let confirmationHandled = false
 
-  if (transactionHandler.mode === 'send') {
-    const sendResult = await callWithOptionalArgs(
-      transactionHandler.handler,
-      transaction,
-      connection,
-      { preflightCommitment: 'confirmed' }
-    )
+  if (typeof signAndSendTransactionFn === 'function') {
+    try {
+      const transaction = buildTransaction()
+      const unsignedRaw = serialiseTransaction(transaction)
 
-    if (typeof sendResult === 'string') {
-      signature = sendResult
-    } else if (sendResult?.signature) {
-      signature = sendResult.signature
-      signedTransactionRaw = sendResult?.rawTransaction
-    } else if (sendResult) {
-      if (typeof sendResult === 'object') {
-        throw new Error('Unexpected response from Solana wallet when sending transaction.')
+      if (!unsignedRaw) {
+        throw new Error('Failed to serialise transaction for Privy signAndSendTransaction.')
       }
-      signature = String(sendResult)
+
+      log.log?.('🔄 Processing Solana transaction via Privy signAndSendTransaction...', {
+        lamports,
+        totalCostSol,
+        usdPerSol,
+        walletAddress,
+        serverWallet: serverWalletAddress,
+        chain: chainIdentifier
+      })
+
+      const sendResult = await signAndSendTransactionFn({
+        transaction: unsignedRaw,
+        wallet: solanaWallet,
+        chain: chainIdentifier,
+        options: preflightOptions
+      })
+
+      const resolvedSignature = normaliseSignature(sendResult?.signature || sendResult)
+
+      if (!resolvedSignature) {
+        throw new Error('Privy signAndSendTransaction did not return a signature.')
+      }
+
+      signature = resolvedSignature
+      signedTransactionRaw = unsignedRaw
+      signingMode = 'privy:signAndSendTransaction'
+
+      await connection.confirmTransaction(
+        {
+          signature,
+          ...latestBlockhash
+        },
+        'confirmed'
+      )
+
+      confirmationHandled = true
+      log.log?.('✅ Solana transaction confirmed via Privy signAndSendTransaction', {
+        signature,
+        lamports,
+        totalCostSol,
+        rpcEndpoint: endpoint
+      })
+    } catch (error) {
+      log.warn?.('⚠️ Privy signAndSendTransaction failed, attempting fallback signing logic.', error)
+      signature = undefined
+      signedTransactionRaw = undefined
+      signingMode = undefined
+      confirmationHandled = false
     }
-  } else if (transactionHandler.mode === 'sign') {
-    const signedResult = await callWithOptionalArgs(transactionHandler.handler, transaction, connection, {
-      preflightCommitment: 'confirmed'
+  }
+
+  if (!signature && typeof signTransactionFn === 'function') {
+    try {
+      const transaction = buildTransaction()
+      const unsignedRaw = serialiseTransaction(transaction)
+
+      if (!unsignedRaw) {
+        throw new Error('Failed to serialise transaction for Privy signTransaction.')
+      }
+
+      log.log?.('🔄 Processing Solana transaction via Privy signTransaction...', {
+        lamports,
+        totalCostSol,
+        usdPerSol,
+        walletAddress,
+        serverWallet: serverWalletAddress,
+        chain: chainIdentifier
+      })
+
+      const signedResult = await signTransactionFn({
+        transaction: unsignedRaw,
+        wallet: solanaWallet,
+        chain: chainIdentifier,
+        options: preflightOptions
+      })
+
+      const signedBytes = toUint8Array(signedResult?.signedTransaction || signedResult)
+
+      if (!signedBytes) {
+        throw new Error('Privy signTransaction did not return signed transaction bytes.')
+      }
+
+      signedTransactionRaw = signedBytes
+      signingMode = 'privy:signTransaction'
+      signature = normaliseSignature(signedResult?.signature)
+
+      if (signature) {
+        await connection.confirmTransaction(
+          {
+            signature,
+            ...latestBlockhash
+          },
+          'confirmed'
+        )
+
+        confirmationHandled = true
+      } else {
+        signature = await connection.sendRawTransaction(signedBytes, preflightOptions)
+        confirmationHandled = false
+      }
+
+      log.log?.('✅ Solana transaction signed via Privy signTransaction', {
+        signature,
+        lamports,
+        totalCostSol,
+        rpcEndpoint: endpoint
+      })
+    } catch (error) {
+      log.warn?.('⚠️ Privy signTransaction failed, falling back to automatic wallet detection.', error)
+      signature = undefined
+      signedTransactionRaw = undefined
+      signingMode = undefined
+      confirmationHandled = false
+    }
+  }
+
+  if (!signature) {
+    const transaction = buildTransaction()
+    const transactionHandler = await selectSendTransaction(solanaWallet, privyUser)
+
+    if (!transactionHandler || !transactionHandler.handler || !transactionHandler.mode) {
+      throw new Error('Unable to access signing capabilities for the connected Solana wallet.')
+    }
+
+    log.log?.('🔄 Processing Solana transaction via auto-detected wallet handler...', {
+      lamports,
+      totalCostSol,
+      usdPerSol,
+      walletAddress,
+      serverWallet: serverWalletAddress,
+      handlerMode: transactionHandler.mode
     })
 
-    const { raw, signature: providedSignature } = normaliseSignedTransaction(signedResult)
+    if (transactionHandler.mode === 'send') {
+      const sendResult = await callWithOptionalArgs(
+        transactionHandler.handler,
+        transaction,
+        connection,
+        preflightOptions
+      )
 
-    if (providedSignature) {
-      signature = providedSignature
+      if (typeof sendResult === 'string') {
+        signature = sendResult
+      } else if (sendResult?.signature) {
+        signature = sendResult.signature
+        signedTransactionRaw = sendResult?.rawTransaction
+      } else if (sendResult) {
+        if (typeof sendResult === 'object') {
+          throw new Error('Unexpected response from Solana wallet when sending transaction.')
+        }
+        signature = String(sendResult)
+      }
+    } else if (transactionHandler.mode === 'sign') {
+      const signedResult = await callWithOptionalArgs(transactionHandler.handler, transaction, connection, preflightOptions)
+
+      const { raw, signature: providedSignature } = normaliseSignedTransaction(signedResult)
+
+      if (providedSignature) {
+        signature = providedSignature
+      }
+
+      if (raw && !signedTransactionRaw) {
+        signedTransactionRaw = raw
+      }
+
+      if (!signature) {
+        signature = await connection.sendRawTransaction(raw, preflightOptions)
+      }
+    } else {
+      throw new Error('Unsupported Solana wallet signing mode encountered.')
     }
 
-    if (raw && !signedTransactionRaw) {
-      signedTransactionRaw = raw
-    }
-
-    if (!signature) {
-      signature = await connection.sendRawTransaction(raw, {
-        preflightCommitment: 'confirmed'
-      })
-    }
-  } else {
-    throw new Error('Unsupported Solana wallet signing mode encountered.')
+    signingMode = transactionHandler.mode
+    confirmationHandled = false
   }
 
   if (!signature) {
     throw new Error('Failed to obtain a Solana transaction signature from the wallet.')
   }
 
-  log.log?.('📝 Transaction submitted. Awaiting confirmation…', signature)
+  if (!confirmationHandled) {
+    log.log?.('📝 Transaction submitted. Awaiting confirmation…', signature)
 
-  await connection.confirmTransaction(
-    {
-      signature,
-      blockhash: latestBlockhash.blockhash,
-      lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
-    },
-    'confirmed'
-  )
+    await connection.confirmTransaction(
+      {
+        signature,
+        blockhash: latestBlockhash.blockhash,
+        lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
+      },
+      'confirmed'
+    )
 
-  log.log?.('✅ Solana transaction confirmed!')
+    log.log?.('✅ Solana transaction confirmed!')
+  }
 
   return {
     signature,
@@ -649,7 +843,8 @@ export const deductPaidRoomFee = async ({
     rpcEndpoint: endpoint,
     walletAddress,
     serverWallet: serverWalletAddress,
-    rawTransaction: signedTransactionRaw
+    rawTransaction: signedTransactionRaw,
+    signingMode
   }
 }
 


### PR DESCRIPTION
## Summary
- integrate Privy signAndSendTransaction / signTransaction helpers into the paid fee manager and normalize signatures with bs58
- provide the Solana chain identifier from the client and pass Privy signing callbacks into the fee deduction flow
- keep the existing auto-detected wallet fallback while confirming transactions after Privy signing succeeds

## Testing
- `npm run lint` *(fails: repository already contains unrelated lint errors such as invalid hooks and missing components)*

------
https://chatgpt.com/codex/tasks/task_e_68e4ae783198833098296b4085e14243