### PR TITLE
Improve Privy Solana signing compatibility

### DIFF
--- a/lib/paid/feeManager.js
+++ b/lib/paid/feeManager.js
@@ -476,6 +476,68 @@ const normaliseSignature = (value) => {
   return null
 }
 
+const decodeBase64 = (value) => {
+  if (typeof value !== 'string' || !value.trim()) {
+    return null
+  }
+
+  const trimmed = value.trim()
+
+  try {
+    if (typeof Buffer !== 'undefined') {
+      const decoded = Buffer.from(trimmed, 'base64')
+      if (decoded?.length) {
+        return new Uint8Array(decoded.buffer, decoded.byteOffset, decoded.byteLength)
+      }
+    }
+  } catch (error) {
+    console.warn('⚠️ Failed to decode base64 transaction string via Buffer:', error)
+  }
+
+  if (typeof atob === 'function') {
+    try {
+      const binary = atob(trimmed)
+      const bytes = new Uint8Array(binary.length)
+      for (let i = 0; i < binary.length; i += 1) {
+        bytes[i] = binary.charCodeAt(i)
+      }
+      return bytes
+    } catch (error) {
+      console.warn('⚠️ Failed to decode base64 transaction string via atob:', error)
+    }
+  }
+
+  return null
+}
+
+const encodeBase64 = (bytes) => {
+  if (!(bytes instanceof Uint8Array) || !bytes.length) {
+    return null
+  }
+
+  try {
+    if (typeof Buffer !== 'undefined') {
+      return Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength).toString('base64')
+    }
+  } catch (error) {
+    console.warn('⚠️ Failed to encode transaction bytes via Buffer:', error)
+  }
+
+  if (typeof btoa === 'function') {
+    try {
+      let binary = ''
+      for (let i = 0; i < bytes.length; i += 1) {
+        binary += String.fromCharCode(bytes[i])
+      }
+      return btoa(binary)
+    } catch (error) {
+      console.warn('⚠️ Failed to encode transaction bytes via btoa:', error)
+    }
+  }
+
+  return null
+}
+
 const toUint8Array = (value) => {
   if (!value) {
     return null
@@ -501,7 +563,58 @@ const toUint8Array = (value) => {
     return Uint8Array.from(value)
   }
 
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+
+    if (!trimmed) {
+      return null
+    }
+
+    try {
+      const decoded = bs58.decode(trimmed)
+      if (decoded?.length) {
+        return new Uint8Array(decoded.buffer, decoded.byteOffset, decoded.byteLength)
+      }
+    } catch (error) {
+      // Not a valid base58 string, fall back to base64 attempt below
+    }
+
+    return decodeBase64(trimmed)
+  }
+
   return null
+}
+
+const createPrivyTransactionAttempts = (transaction, unsignedRaw, baseArgs = {}) => {
+  const attempts = []
+
+  const pushAttempt = (descriptor, payload) => {
+    if (!payload) {
+      return
+    }
+
+    attempts.push({
+      descriptor,
+      args: {
+        ...baseArgs,
+        transaction: payload
+      }
+    })
+  }
+
+  pushAttempt('transaction-object', transaction)
+
+  if (unsignedRaw instanceof Uint8Array && unsignedRaw.length) {
+    pushAttempt('uint8array', unsignedRaw)
+    pushAttempt('number-array', Array.from(unsignedRaw))
+
+    const base64 = encodeBase64(unsignedRaw)
+    if (base64) {
+      pushAttempt('base64-string', base64)
+    }
+  }
+
+  return attempts
 }
 
 const normaliseSignedTransaction = (signedResult) => {
@@ -641,47 +754,71 @@ export const deductPaidRoomFee = async ({
         throw new Error('Failed to serialise transaction for Privy signAndSendTransaction.')
       }
 
-      log.log?.('🔄 Processing Solana transaction via Privy signAndSendTransaction...', {
-        lamports,
-        totalCostSol,
-        usdPerSol,
-        walletAddress,
-        serverWallet: serverWalletAddress,
-        chain: chainIdentifier
-      })
-
-      const sendResult = await signAndSendTransactionFn({
-        transaction: unsignedRaw,
+      const attemptBase = {
         wallet: solanaWallet,
         chain: chainIdentifier,
         options: preflightOptions
-      })
-
-      const resolvedSignature = normaliseSignature(sendResult?.signature || sendResult)
-
-      if (!resolvedSignature) {
-        throw new Error('Privy signAndSendTransaction did not return a signature.')
       }
 
-      signature = resolvedSignature
-      signedTransactionRaw = unsignedRaw
-      signingMode = 'privy:signAndSendTransaction'
+      let lastError
 
-      await connection.confirmTransaction(
-        {
-          signature,
-          ...latestBlockhash
-        },
-        'confirmed'
-      )
+      for (const attempt of createPrivyTransactionAttempts(transaction, unsignedRaw, attemptBase)) {
+        try {
+          log.log?.('🔄 Processing Solana transaction via Privy signAndSendTransaction...', {
+            lamports,
+            totalCostSol,
+            usdPerSol,
+            walletAddress,
+            serverWallet: serverWalletAddress,
+            chain: chainIdentifier,
+            payloadType: attempt.descriptor
+          })
 
-      confirmationHandled = true
-      log.log?.('✅ Solana transaction confirmed via Privy signAndSendTransaction', {
-        signature,
-        lamports,
-        totalCostSol,
-        rpcEndpoint: endpoint
-      })
+          const sendResult = await signAndSendTransactionFn(attempt.args)
+          const resolvedSignature = normaliseSignature(sendResult?.signature || sendResult)
+
+          if (!resolvedSignature) {
+            throw new Error('Privy signAndSendTransaction did not return a signature.')
+          }
+
+          signature = resolvedSignature
+          signedTransactionRaw = unsignedRaw
+          signingMode = 'privy:signAndSendTransaction'
+
+          await connection.confirmTransaction(
+            {
+              signature,
+              ...latestBlockhash
+            },
+            'confirmed'
+          )
+
+          confirmationHandled = true
+          log.log?.('✅ Solana transaction confirmed via Privy signAndSendTransaction', {
+            signature,
+            lamports,
+            totalCostSol,
+            rpcEndpoint: endpoint,
+            payloadType: attempt.descriptor
+          })
+
+          break
+        } catch (attemptError) {
+          lastError = attemptError
+          signature = undefined
+          signedTransactionRaw = undefined
+          signingMode = undefined
+          confirmationHandled = false
+          log.warn?.(
+            `⚠️ Privy signAndSendTransaction attempt failed for payload type ${attempt.descriptor}.`,
+            attemptError
+          )
+        }
+      }
+
+      if (!signature) {
+        throw lastError || new Error('Privy signAndSendTransaction did not succeed with any payload type.')
+      }
     } catch (error) {
       log.warn?.('⚠️ Privy signAndSendTransaction failed, attempting fallback signing logic.', error)
       signature = undefined
@@ -700,53 +837,77 @@ export const deductPaidRoomFee = async ({
         throw new Error('Failed to serialise transaction for Privy signTransaction.')
       }
 
-      log.log?.('🔄 Processing Solana transaction via Privy signTransaction...', {
-        lamports,
-        totalCostSol,
-        usdPerSol,
-        walletAddress,
-        serverWallet: serverWalletAddress,
-        chain: chainIdentifier
-      })
-
-      const signedResult = await signTransactionFn({
-        transaction: unsignedRaw,
+      const attemptBase = {
         wallet: solanaWallet,
         chain: chainIdentifier,
         options: preflightOptions
-      })
-
-      const signedBytes = toUint8Array(signedResult?.signedTransaction || signedResult)
-
-      if (!signedBytes) {
-        throw new Error('Privy signTransaction did not return signed transaction bytes.')
       }
 
-      signedTransactionRaw = signedBytes
-      signingMode = 'privy:signTransaction'
-      signature = normaliseSignature(signedResult?.signature)
+      let lastError
 
-      if (signature) {
-        await connection.confirmTransaction(
-          {
+      for (const attempt of createPrivyTransactionAttempts(transaction, unsignedRaw, attemptBase)) {
+        try {
+          log.log?.('🔄 Processing Solana transaction via Privy signTransaction...', {
+            lamports,
+            totalCostSol,
+            usdPerSol,
+            walletAddress,
+            serverWallet: serverWalletAddress,
+            chain: chainIdentifier,
+            payloadType: attempt.descriptor
+          })
+
+          const signedResult = await signTransactionFn(attempt.args)
+          const signedBytes = toUint8Array(signedResult?.signedTransaction || signedResult)
+
+          if (!signedBytes) {
+            throw new Error('Privy signTransaction did not return signed transaction bytes.')
+          }
+
+          signedTransactionRaw = signedBytes
+          signingMode = 'privy:signTransaction'
+          signature = normaliseSignature(signedResult?.signature)
+
+          if (signature) {
+            await connection.confirmTransaction(
+              {
+                signature,
+                ...latestBlockhash
+              },
+              'confirmed'
+            )
+
+            confirmationHandled = true
+          } else {
+            signature = await connection.sendRawTransaction(signedBytes, preflightOptions)
+            confirmationHandled = false
+          }
+
+          log.log?.('✅ Solana transaction signed via Privy signTransaction', {
             signature,
-            ...latestBlockhash
-          },
-          'confirmed'
-        )
+            lamports,
+            totalCostSol,
+            rpcEndpoint: endpoint,
+            payloadType: attempt.descriptor
+          })
 
-        confirmationHandled = true
-      } else {
-        signature = await connection.sendRawTransaction(signedBytes, preflightOptions)
-        confirmationHandled = false
+          break
+        } catch (attemptError) {
+          lastError = attemptError
+          signature = undefined
+          signedTransactionRaw = undefined
+          signingMode = undefined
+          confirmationHandled = false
+          log.warn?.(
+            `⚠️ Privy signTransaction attempt failed for payload type ${attempt.descriptor}.`,
+            attemptError
+          )
+        }
       }
 
-      log.log?.('✅ Solana transaction signed via Privy signTransaction', {
-        signature,
-        lamports,
-        totalCostSol,
-        rpcEndpoint: endpoint
-      })
+      if (!signature && !signedTransactionRaw) {
+        throw lastError || new Error('Privy signTransaction did not succeed with any payload type.')
+      }
     } catch (error) {
       log.warn?.('⚠️ Privy signTransaction failed, falling back to automatic wallet detection.', error)
       signature = undefined


### PR DESCRIPTION
## Summary
- add helpers to normalise Solana transaction payload formats, including base64 handling
- attempt multiple payload shapes when calling Privy signAndSendTransaction/signTransaction to better support embedded wallets
- enhance logging and fallback behaviour when Privy signing attempts fail

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4b40a7a70833080078adb50759f8b