### PR TITLE
Fix Privy Solana signing for paid room fees

### DIFF
--- a/lib/paid/feeManager.js
+++ b/lib/paid/feeManager.js
@@ -132,308 +132,6 @@ export const buildSolanaRpcEndpointList = ({
   )
 }
 
-const bindHandler = (fn, context) => (typeof fn === 'function' ? fn.bind(context) : null)
-
-const getGlobalObject = () => {
-  if (typeof globalThis !== 'undefined') {
-    return globalThis
-  }
-  if (typeof window !== 'undefined') {
-    return window
-  }
-  if (typeof self !== 'undefined') {
-    return self
-  }
-  return undefined
-}
-
-const collectGlobalSolanaProviders = () => {
-  const candidates = []
-  const seen = new Set()
-  const push = (provider) => {
-    if (provider && !seen.has(provider)) {
-      seen.add(provider)
-      candidates.push(provider)
-    }
-  }
-
-  const globalObj = getGlobalObject()
-  if (!globalObj) {
-    return candidates
-  }
-
-  const directCandidates = [
-    globalObj.solana,
-    globalObj.phantom?.solana,
-    globalObj.backpack?.solana,
-    globalObj.glow?.solana,
-    globalObj.solflare?.solana,
-    globalObj.slope?.solana,
-    globalObj.sollet?.solana || globalObj.sollet
-  ]
-
-  for (const direct of directCandidates) {
-    push(direct)
-  }
-
-  const providerCollections = [
-    Array.isArray(globalObj.solana?.providers) ? globalObj.solana.providers : [],
-    Array.isArray(globalObj.solanaProviders) ? globalObj.solanaProviders : [],
-    Array.isArray(globalObj.phantom?.providers) ? globalObj.phantom.providers : []
-  ]
-
-  for (const collection of providerCollections) {
-    for (const provider of collection) {
-      push(provider)
-    }
-  }
-
-  return candidates
-}
-
-const collectSendCandidates = (source) =>
-  [
-    bindHandler(source?.sendTransaction, source),
-    bindHandler(source?.signAndSendTransaction, source),
-    bindHandler(source?.signAndSendSolanaTransaction, source),
-    bindHandler(source?.sendAndConfirmTransaction, source),
-    bindHandler(source?.signTransactionAndSend, source),
-    bindHandler(source?.solana?.sendTransaction, source?.solana),
-    bindHandler(source?.solana?.signAndSendTransaction, source?.solana),
-    bindHandler(source?.solana?.signAndSendSolanaTransaction, source?.solana),
-    bindHandler(source?.solana?.sendAndConfirmTransaction, source?.solana),
-    bindHandler(source?.wallet?.sendTransaction, source?.wallet),
-    bindHandler(source?.wallet?.signAndSendTransaction, source?.wallet),
-    bindHandler(source?.wallet?.sendAndConfirmTransaction, source?.wallet),
-    bindHandler(source?.provider?.sendTransaction, source?.provider),
-    bindHandler(source?.provider?.signAndSendTransaction, source?.provider),
-    bindHandler(source?.provider?.sendAndConfirmTransaction, source?.provider),
-    bindHandler(source?.adapter?.sendTransaction, source?.adapter),
-    bindHandler(source?.adapter?.signAndSendTransaction, source?.adapter),
-    bindHandler(source?.adapter?.sendAndConfirmTransaction, source?.adapter)
-  ].filter(Boolean)
-
-const collectSignCandidates = (source) =>
-  [
-    bindHandler(source?.signTransaction, source),
-    bindHandler(source?.signSolanaTransaction, source),
-    bindHandler(source?.solana?.signTransaction, source?.solana),
-    bindHandler(source?.solana?.signSolanaTransaction, source?.solana),
-    bindHandler(source?.wallet?.signTransaction, source?.wallet),
-    bindHandler(source?.wallet?.signSolanaTransaction, source?.wallet),
-    bindHandler(source?.provider?.signTransaction, source?.provider),
-    bindHandler(source?.provider?.signSolanaTransaction, source?.provider),
-    bindHandler(source?.adapter?.signTransaction, source?.adapter),
-    bindHandler(source?.adapter?.signSolanaTransaction, source?.adapter)
-  ].filter(Boolean)
-
-const callWithOptionalArgs = (handler, transaction, connection, options) => {
-  if (typeof handler !== 'function') {
-    throw new Error('Invalid Solana transaction handler provided.')
-  }
-
-  const expectedArgs = Number.isInteger(handler.length) ? handler.length : 0
-
-  if (expectedArgs >= 3) {
-    return handler(transaction, connection, options)
-  }
-  if (expectedArgs === 2) {
-    return handler(transaction, connection)
-  }
-
-  return handler(transaction)
-}
-
-const resolveHandlerFromSource = (source) => {
-  if (!source) {
-    return null
-  }
-
-  for (const candidate of collectSendCandidates(source)) {
-    if (candidate) {
-      return { mode: 'send', handler: candidate }
-    }
-  }
-
-  for (const candidate of collectSignCandidates(source)) {
-    if (candidate) {
-      return { mode: 'sign', handler: candidate }
-    }
-  }
-
-  return null
-}
-
-const selectSendTransaction = async (solanaWallet, privyUser) => {
-  const checkedSources = new Set()
-  const queue = []
-  const queuedSources = new WeakSet()
-
-  const enqueue = (candidate) => {
-    if (!candidate || (typeof candidate === 'object' && candidate !== null && queuedSources.has(candidate))) {
-      return
-    }
-
-    if (typeof candidate === 'object' && candidate !== null) {
-      queuedSources.add(candidate)
-    }
-
-    queue.push(candidate)
-
-    const nestedCandidates = []
-
-    if (candidate?.solana) {
-      nestedCandidates.push(candidate.solana)
-    }
-
-    if (candidate?.wallet) {
-      nestedCandidates.push(candidate.wallet)
-    }
-
-    if (candidate?.provider) {
-      nestedCandidates.push(candidate.provider)
-    }
-
-    if (candidate?.adapter) {
-      nestedCandidates.push(candidate.adapter)
-    }
-
-    if (Array.isArray(candidate?.providers)) {
-      nestedCandidates.push(...candidate.providers.filter(Boolean))
-    }
-
-    for (const nested of nestedCandidates) {
-      enqueue(nested)
-    }
-  }
-
-  if (solanaWallet) {
-    enqueue(solanaWallet)
-
-    if (solanaWallet.walletClient) {
-      enqueue(solanaWallet.walletClient)
-    }
-
-    if (solanaWallet.walletClient?.solana) {
-      enqueue(solanaWallet.walletClient.solana)
-    }
-
-    if (solanaWallet.adapter) {
-      enqueue(solanaWallet.adapter)
-    }
-  }
-
-  if (typeof solanaWallet?.getWalletClient === 'function') {
-    try {
-      const client = await solanaWallet.getWalletClient()
-      if (client) {
-        enqueue(client)
-      }
-    } catch (error) {
-      console.warn('⚠️ Failed to resolve wallet client for Solana wallet:', error)
-    }
-  }
-
-  if (typeof solanaWallet?.getProvider === 'function') {
-    try {
-      const provider = await solanaWallet.getProvider()
-      if (provider) {
-        enqueue(provider)
-      }
-    } catch (error) {
-      console.warn('⚠️ Failed to resolve Solana provider from wallet:', error)
-    }
-  }
-
-  if (privyUser?.wallet) {
-    enqueue(privyUser.wallet)
-
-    if (privyUser.wallet.walletClient) {
-      enqueue(privyUser.wallet.walletClient)
-    }
-
-    if (typeof privyUser.wallet.getWalletClient === 'function') {
-      try {
-        const embeddedClient = await privyUser.wallet.getWalletClient()
-        if (embeddedClient) {
-          enqueue(embeddedClient)
-        }
-      } catch (error) {
-        console.warn('⚠️ Failed to resolve embedded wallet client:', error)
-      }
-    }
-
-    if (typeof privyUser.wallet.getProvider === 'function') {
-      try {
-        const embeddedProvider = await privyUser.wallet.getProvider()
-        if (embeddedProvider) {
-          enqueue(embeddedProvider)
-        }
-      } catch (error) {
-        console.warn('⚠️ Failed to resolve embedded wallet provider:', error)
-      }
-    }
-  }
-
-  if (Array.isArray(privyUser?.linkedAccounts)) {
-    for (const account of privyUser.linkedAccounts) {
-      enqueue(account)
-
-      if (account?.walletClient) {
-        enqueue(account.walletClient)
-      }
-
-      if (typeof account?.getWalletClient === 'function') {
-        try {
-          const linkedClient = await account.getWalletClient()
-          if (linkedClient) {
-            enqueue(linkedClient)
-          }
-        } catch (error) {
-          console.warn('⚠️ Failed to resolve linked account wallet client:', error)
-        }
-      }
-
-      if (typeof account?.getProvider === 'function') {
-        try {
-          const linkedProvider = await account.getProvider()
-          if (linkedProvider) {
-            enqueue(linkedProvider)
-          }
-        } catch (error) {
-          console.warn('⚠️ Failed to resolve linked account provider:', error)
-        }
-      }
-    }
-  }
-
-  for (const browserProvider of collectGlobalSolanaProviders()) {
-    enqueue(browserProvider)
-
-    if (browserProvider?.provider) {
-      enqueue(browserProvider.provider)
-    }
-
-    if (browserProvider?.wallet) {
-      enqueue(browserProvider.wallet)
-    }
-  }
-
-  for (const source of queue) {
-    if (!source || checkedSources.has(source)) {
-      continue
-    }
-    checkedSources.add(source)
-
-    const handler = resolveHandlerFromSource(source)
-    if (handler) {
-      return handler
-    }
-  }
-
-  return null
-}
-
 const deriveSolanaChainIdentifier = (chain) => {
   if (!chain) {
     return 'solana:mainnet'
@@ -460,15 +158,6 @@ const deriveSolanaChainIdentifier = (chain) => {
   return `solana:${normalised}`
 }
 
-const serialiseTransaction = (transaction) => {
-  try {
-    const raw = transaction.serialize({ requireAllSignatures: false, verifySignatures: false })
-    return toUint8Array(raw)
-  } catch (error) {
-    throw new Error(`Unable to serialise Solana transaction for signing: ${error?.message || error}`)
-  }
-}
-
 const normaliseSignature = (value) => {
   if (!value) {
     return null
@@ -481,6 +170,70 @@ const normaliseSignature = (value) => {
   const bytes = toUint8Array(value)
   if (bytes) {
     return bs58.encode(bytes)
+  }
+
+  return null
+}
+
+const extractWalletIdentifier = (candidate) => {
+  if (!candidate) {
+    return null
+  }
+
+  if (typeof candidate === 'string' && candidate.trim()) {
+    return candidate.trim()
+  }
+
+  const candidateFields = ['walletId', 'id', 'address', 'accountAddress']
+
+  for (const field of candidateFields) {
+    const value = candidate?.[field]
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim()
+    }
+  }
+
+  const publicKey = candidate?.publicKey
+  if (publicKey) {
+    if (typeof publicKey === 'string' && publicKey.trim()) {
+      return publicKey.trim()
+    }
+
+    if (typeof publicKey?.toBase58 === 'function') {
+      const derived = publicKey.toBase58()
+      if (derived) {
+        return derived
+      }
+    }
+
+    if (typeof publicKey?.toString === 'function') {
+      const derived = publicKey.toString()
+      if (derived) {
+        return derived
+      }
+    }
+  }
+
+  return null
+}
+
+const resolvePrivyWalletIdentifier = (solanaWallet, privyUser, fallbackAddress) => {
+  const candidates = [solanaWallet, solanaWallet?.walletClient, privyUser?.wallet]
+
+  if (Array.isArray(privyUser?.linkedAccounts)) {
+    candidates.push(...privyUser.linkedAccounts)
+  }
+
+  for (const candidate of candidates) {
+    const identifier = extractWalletIdentifier(candidate)
+    if (identifier) {
+      return identifier
+    }
+  }
+
+  const fallbackIdentifier = extractWalletIdentifier(fallbackAddress)
+  if (fallbackIdentifier) {
+    return fallbackIdentifier
   }
 
   return null
@@ -514,34 +267,6 @@ const decodeBase64 = (value) => {
       return bytes
     } catch (error) {
       console.warn('⚠️ Failed to decode base64 transaction string via atob:', error)
-    }
-  }
-
-  return null
-}
-
-const encodeBase64 = (bytes) => {
-  if (!(bytes instanceof Uint8Array) || !bytes.length) {
-    return null
-  }
-
-  try {
-    if (typeof Buffer !== 'undefined') {
-      return Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength).toString('base64')
-    }
-  } catch (error) {
-    console.warn('⚠️ Failed to encode transaction bytes via Buffer:', error)
-  }
-
-  if (typeof btoa === 'function') {
-    try {
-      let binary = ''
-      for (let i = 0; i < bytes.length; i += 1) {
-        binary += String.fromCharCode(bytes[i])
-      }
-      return btoa(binary)
-    } catch (error) {
-      console.warn('⚠️ Failed to encode transaction bytes via btoa:', error)
     }
   }
 
@@ -593,38 +318,6 @@ const toUint8Array = (value) => {
   }
 
   return null
-}
-
-const createPrivyTransactionAttempts = (transaction, unsignedRaw, baseArgs = {}) => {
-  const attempts = []
-
-  const pushAttempt = (descriptor, payload) => {
-    if (!payload) {
-      return
-    }
-
-    attempts.push({
-      descriptor,
-      args: {
-        ...baseArgs,
-        transaction: payload
-      }
-    })
-  }
-
-  pushAttempt('transaction-object', transaction)
-
-  if (unsignedRaw instanceof Uint8Array && unsignedRaw.length) {
-    pushAttempt('uint8array', unsignedRaw)
-    pushAttempt('number-array', Array.from(unsignedRaw))
-
-    const base64 = encodeBase64(unsignedRaw)
-    if (base64) {
-      pushAttempt('base64-string', base64)
-    }
-  }
-
-  return attempts
 }
 
 const normaliseSignedTransaction = (signedResult) => {
@@ -823,262 +516,125 @@ export const deductPaidRoomFee = async ({
   let signingMode
   let confirmationHandled = false
 
+  const walletIdentifier = resolvePrivyWalletIdentifier(solanaWallet, privyUser, walletAddress)
+
+  const createPrivyRequest = (transaction) => {
+    const request = {
+      transaction,
+      chain: chainIdentifier,
+      options: preflightOptions
+    }
+
+    if (walletIdentifier) {
+      request.walletId = walletIdentifier
+    }
+
+    return request
+  }
+
+  const logContext = {
+    entryLamports,
+    feeLamports,
+    totalLamports,
+    totalCostSol,
+    usdPerSol,
+    walletAddress,
+    prizeVault,
+    feeVault,
+    chain: chainIdentifier,
+    memoAttached: Boolean(memoPayload)
+  }
+
+  const privyErrors = []
+
   if (typeof signAndSendTransactionFn === 'function') {
+    const transaction = buildTransaction()
     try {
-      const transaction = buildTransaction()
-      const unsignedRaw = serialiseTransaction(transaction)
+      log.log?.('🔄 Processing Solana transaction via Privy signAndSendTransaction...', logContext)
+      const sendResult = await signAndSendTransactionFn(createPrivyRequest(transaction))
+      const resolvedSignature = normaliseSignature(sendResult?.signature || sendResult)
 
-      if (!unsignedRaw) {
-        throw new Error('Failed to serialise transaction for Privy signAndSendTransaction.')
+      if (!resolvedSignature) {
+        throw new Error('Privy signAndSendTransaction did not return a transaction signature.')
       }
 
-      const attemptBase = {
-        wallet: solanaWallet,
-        chain: chainIdentifier,
-        options: preflightOptions
-      }
+      signature = resolvedSignature
+      signingMode = 'privy:signAndSendTransaction'
+      signedTransactionRaw = toUint8Array(sendResult?.rawTransaction) || null
 
-      let lastError
+      await connection.confirmTransaction(
+        {
+          signature,
+          ...latestBlockhash
+        },
+        'confirmed'
+      )
 
-      for (const attempt of createPrivyTransactionAttempts(transaction, unsignedRaw, attemptBase)) {
-        try {
-          log.log?.('🔄 Processing Solana transaction via Privy signAndSendTransaction...', {
-            entryLamports,
-            feeLamports,
-            totalLamports,
-            totalCostSol,
-            usdPerSol,
-            walletAddress,
-            prizeVault,
-            feeVault,
-            chain: chainIdentifier,
-            memoAttached: Boolean(memoPayload),
-            payloadType: attempt.descriptor
-          })
-
-          const sendResult = await signAndSendTransactionFn(attempt.args)
-          const resolvedSignature = normaliseSignature(sendResult?.signature || sendResult)
-
-          if (!resolvedSignature) {
-            throw new Error('Privy signAndSendTransaction did not return a signature.')
-          }
-
-          signature = resolvedSignature
-          signedTransactionRaw = unsignedRaw
-          signingMode = 'privy:signAndSendTransaction'
-
-          await connection.confirmTransaction(
-            {
-              signature,
-              ...latestBlockhash
-            },
-            'confirmed'
-          )
-
-          confirmationHandled = true
-          log.log?.('✅ Solana transaction confirmed via Privy signAndSendTransaction', {
-            signature,
-            entryLamports,
-            feeLamports,
-            totalLamports,
-            totalCostSol,
-            rpcEndpoint: endpoint,
-            prizeVault,
-            feeVault,
-            memoAttached: Boolean(memoPayload),
-            payloadType: attempt.descriptor
-          })
-
-          break
-        } catch (attemptError) {
-          lastError = attemptError
-          signature = undefined
-          signedTransactionRaw = undefined
-          signingMode = undefined
-          confirmationHandled = false
-          log.warn?.(
-            `⚠️ Privy signAndSendTransaction attempt failed for payload type ${attempt.descriptor}.`,
-            attemptError
-          )
-        }
-      }
-
-      if (!signature) {
-        throw lastError || new Error('Privy signAndSendTransaction did not succeed with any payload type.')
-      }
+      confirmationHandled = true
+      log.log?.('✅ Solana transaction confirmed via Privy signAndSendTransaction', {
+        ...logContext,
+        signature,
+        rpcEndpoint: endpoint
+      })
     } catch (error) {
-      log.warn?.('⚠️ Privy signAndSendTransaction failed, attempting fallback signing logic.', error)
+      privyErrors.push(error)
+      log.error?.('❌ Privy signAndSendTransaction failed.', error)
       signature = undefined
-      signedTransactionRaw = undefined
       signingMode = undefined
+      signedTransactionRaw = undefined
       confirmationHandled = false
     }
   }
 
   if (!signature && typeof signTransactionFn === 'function') {
+    const transaction = buildTransaction()
     try {
-      const transaction = buildTransaction()
-      const unsignedRaw = serialiseTransaction(transaction)
+      log.log?.('🔄 Processing Solana transaction via Privy signTransaction...', logContext)
+      const signedResult = await signTransactionFn(createPrivyRequest(transaction))
+      const { raw, signature: providedSignature } = normaliseSignedTransaction(signedResult)
 
-      if (!unsignedRaw) {
-        throw new Error('Failed to serialise transaction for Privy signTransaction.')
+      if (!raw) {
+        throw new Error('Privy signTransaction did not return signed transaction bytes.')
       }
 
-      const attemptBase = {
-        wallet: solanaWallet,
-        chain: chainIdentifier,
-        options: preflightOptions
-      }
+      signedTransactionRaw = raw
+      signingMode = 'privy:signTransaction'
 
-      let lastError
-
-      for (const attempt of createPrivyTransactionAttempts(transaction, unsignedRaw, attemptBase)) {
-        try {
-          log.log?.('🔄 Processing Solana transaction via Privy signTransaction...', {
-            entryLamports,
-            feeLamports,
-            totalLamports,
-            totalCostSol,
-            usdPerSol,
-            walletAddress,
-            prizeVault,
-            feeVault,
-            chain: chainIdentifier,
-            memoAttached: Boolean(memoPayload),
-            payloadType: attempt.descriptor
-          })
-
-          const signedResult = await signTransactionFn(attempt.args)
-          const signedBytes = toUint8Array(signedResult?.signedTransaction || signedResult)
-
-          if (!signedBytes) {
-            throw new Error('Privy signTransaction did not return signed transaction bytes.')
-          }
-
-          signedTransactionRaw = signedBytes
-          signingMode = 'privy:signTransaction'
-          signature = normaliseSignature(signedResult?.signature)
-
-          if (signature) {
-            await connection.confirmTransaction(
-              {
-                signature,
-                ...latestBlockhash
-              },
-              'confirmed'
-            )
-
-            confirmationHandled = true
-          } else {
-            signature = await connection.sendRawTransaction(signedBytes, preflightOptions)
-            confirmationHandled = false
-          }
-
-          log.log?.('✅ Solana transaction signed via Privy signTransaction', {
+      const normalisedSignature = normaliseSignature(providedSignature)
+      if (normalisedSignature) {
+        signature = normalisedSignature
+        await connection.confirmTransaction(
+          {
             signature,
-            entryLamports,
-            feeLamports,
-            totalLamports,
-            totalCostSol,
-            rpcEndpoint: endpoint,
-            prizeVault,
-            feeVault,
-            memoAttached: Boolean(memoPayload),
-            payloadType: attempt.descriptor
-          })
-
-          break
-        } catch (attemptError) {
-          lastError = attemptError
-          signature = undefined
-          signedTransactionRaw = undefined
-          signingMode = undefined
-          confirmationHandled = false
-          log.warn?.(
-            `⚠️ Privy signTransaction attempt failed for payload type ${attempt.descriptor}.`,
-            attemptError
-          )
-        }
+            ...latestBlockhash
+          },
+          'confirmed'
+        )
+        confirmationHandled = true
+      } else {
+        signature = await connection.sendRawTransaction(raw, preflightOptions)
+        confirmationHandled = false
       }
 
-      if (!signature && !signedTransactionRaw) {
-        throw lastError || new Error('Privy signTransaction did not succeed with any payload type.')
-      }
+      log.log?.('✅ Solana transaction signed via Privy signTransaction', {
+        ...logContext,
+        signature,
+        rpcEndpoint: endpoint
+      })
     } catch (error) {
-      log.warn?.('⚠️ Privy signTransaction failed, falling back to automatic wallet detection.', error)
+      privyErrors.push(error)
+      log.error?.('❌ Privy signTransaction failed.', error)
       signature = undefined
-      signedTransactionRaw = undefined
       signingMode = undefined
+      signedTransactionRaw = undefined
       confirmationHandled = false
     }
   }
 
   if (!signature) {
-    const transaction = buildTransaction()
-    const transactionHandler = await selectSendTransaction(solanaWallet, privyUser)
-
-    if (!transactionHandler || !transactionHandler.handler || !transactionHandler.mode) {
-      throw new Error('Unable to access signing capabilities for the connected Solana wallet.')
-    }
-
-    log.log?.('🔄 Processing Solana transaction via auto-detected wallet handler...', {
-      entryLamports,
-      feeLamports,
-      totalLamports,
-      totalCostSol,
-      usdPerSol,
-      walletAddress,
-      prizeVault,
-      feeVault,
-      memoAttached: Boolean(memoPayload),
-      handlerMode: transactionHandler.mode
-    })
-
-    if (transactionHandler.mode === 'send') {
-      const sendResult = await callWithOptionalArgs(
-        transactionHandler.handler,
-        transaction,
-        connection,
-        preflightOptions
-      )
-
-      if (typeof sendResult === 'string') {
-        signature = sendResult
-      } else if (sendResult?.signature) {
-        signature = sendResult.signature
-        signedTransactionRaw = sendResult?.rawTransaction
-      } else if (sendResult) {
-        if (typeof sendResult === 'object') {
-          throw new Error('Unexpected response from Solana wallet when sending transaction.')
-        }
-        signature = String(sendResult)
-      }
-    } else if (transactionHandler.mode === 'sign') {
-      const signedResult = await callWithOptionalArgs(transactionHandler.handler, transaction, connection, preflightOptions)
-
-      const { raw, signature: providedSignature } = normaliseSignedTransaction(signedResult)
-
-      if (providedSignature) {
-        signature = providedSignature
-      }
-
-      if (raw && !signedTransactionRaw) {
-        signedTransactionRaw = raw
-      }
-
-      if (!signature) {
-        signature = await connection.sendRawTransaction(raw, preflightOptions)
-      }
-    } else {
-      throw new Error('Unsupported Solana wallet signing mode encountered.')
-    }
-
-    signingMode = transactionHandler.mode
-    confirmationHandled = false
-  }
-
-  if (!signature) {
-    throw new Error('Failed to obtain a Solana transaction signature from the wallet.')
+    const errorMessages = privyErrors.map((error) => error?.message || error).filter(Boolean)
+    const reason = errorMessages.length ? ` Reason: ${errorMessages.join(' | ')}` : ''
+    throw new Error(`Unable to access signing capabilities for the connected Solana wallet.${reason}`)
   }
 
   if (!confirmationHandled) {


### PR DESCRIPTION
## Summary
- remove the legacy Solana wallet fallback detection flow from `deductPaidRoomFee`
- ensure Privy `signAndSendTransaction` and `signTransaction` are invoked with correct wallet identifiers and logging
- aggregate Privy errors and provide clearer failure messaging when signing capabilities are unavailable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e527ffabe08330a4eb2bc1c26b50f2