### PR TITLE
Handle missing Privy Solana signing fallbacks

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -14,8 +14,10 @@ export default function TurfLootTactical() {
   const { ready, authenticated, user: privyUser, login, logout } = usePrivy()
   const { wallets } = useWallets()
   const { fundWallet } = useFundWallet()
-  const { signAndSendTransaction: privySignAndSendTransaction } = useSignAndSendTransaction()
-  const { signTransaction: privySignTransaction } = useSignTransaction()
+  const signAndSendTransactionResponse = useSignAndSendTransaction()
+  const privySignAndSendTransaction = signAndSendTransactionResponse?.signAndSendTransaction
+  const signTransactionResponse = useSignTransaction()
+  const privySignTransaction = signTransactionResponse?.signTransaction
   
   // LOYALTY SYSTEM STATE
   const [loyaltyData, setLoyaltyData] = useState(null)

--- a/frontend/app/page.js
+++ b/frontend/app/page.js
@@ -15,8 +15,10 @@ export default function TurfLootTactical() {
   const { ready, authenticated, user: privyUser, login, logout } = usePrivy()
   const { wallets } = useWallets()
   const { fundWallet } = useFundWallet()
-  const { signAndSendTransaction: privySignAndSendTransaction } = useSignAndSendTransaction()
-  const { signTransaction: privySignTransaction } = useSignTransaction()
+  const signAndSendTransactionResponse = useSignAndSendTransaction()
+  const privySignAndSendTransaction = signAndSendTransactionResponse?.signAndSendTransaction
+  const signTransactionResponse = useSignTransaction()
+  const privySignTransaction = signTransactionResponse?.signTransaction
   
   // LOYALTY SYSTEM STATE
   const [loyaltyData, setLoyaltyData] = useState(null)

--- a/lib/paid/feeManager.js
+++ b/lib/paid/feeManager.js
@@ -365,6 +365,169 @@ const connectToSolana = async (rpcEndpoints = []) => {
   throw new Error(`Unable to connect to Solana RPC endpoint. Tried: ${errors.join(' | ')}`)
 }
 
+const WALLET_NESTED_KEYS = [
+  'wallet',
+  'walletClient',
+  'adapter',
+  'provider',
+  'signer',
+  'embeddedWallet',
+  'inner',
+  'delegate',
+  'link'
+]
+
+const bindWalletMethod = (wallet, methodNames = []) => {
+  if (!wallet || typeof wallet !== 'object') {
+    return null
+  }
+
+  const visited = new Set()
+  const queue = [{ candidate: wallet, path: 'wallet' }]
+
+  const enqueue = (candidate, path) => {
+    if (!candidate || typeof candidate !== 'object') {
+      return
+    }
+
+    if (visited.has(candidate)) {
+      return
+    }
+
+    visited.add(candidate)
+    queue.push({ candidate, path })
+  }
+
+  while (queue.length > 0) {
+    const { candidate, path } = queue.shift()
+
+    for (const name of methodNames) {
+      if (typeof candidate?.[name] === 'function') {
+        return {
+          method: candidate[name],
+          context: candidate,
+          source: `${path}.${name}`
+        }
+      }
+    }
+
+    for (const key of WALLET_NESTED_KEYS) {
+      if (candidate && typeof candidate[key] === 'object') {
+        enqueue(candidate[key], `${path}.${key}`)
+      }
+    }
+  }
+
+  return null
+}
+
+const adaptDirectSignAndSend = ({ method, context }, connection) => {
+  if (typeof method !== 'function') {
+    return null
+  }
+
+  return async (request) => {
+    const payload = request?.transaction || request
+
+    if (!payload) {
+      throw new Error('Transaction payload missing for wallet signAndSendTransaction call.')
+    }
+
+    const options = request?.options || (request?.preflightCommitment ? { preflightCommitment: request.preflightCommitment } : undefined)
+
+    try {
+      if (method.length >= 3) {
+        return await method.call(context, payload, connection, options)
+      }
+
+      if (method.length === 2) {
+        try {
+          return await method.call(context, payload, connection)
+        } catch (error) {
+          if (options !== undefined) {
+            return await method.call(context, payload, options)
+          }
+          throw error
+        }
+      }
+
+      if (options !== undefined) {
+        return await method.call(context, payload, options)
+      }
+
+      return await method.call(context, payload)
+    } catch (error) {
+      throw error
+    }
+  }
+}
+
+const adaptDirectSignTransaction = ({ method, context }) => {
+  if (typeof method !== 'function') {
+    return null
+  }
+
+  return async (request) => {
+    const payload = request?.transaction || request
+
+    if (!payload) {
+      throw new Error('Transaction payload missing for wallet signTransaction call.')
+    }
+
+    const options = request?.options
+
+    if (method.length >= 2 && options !== undefined) {
+      return await method.call(context, payload, options)
+    }
+
+    return await method.call(context, payload)
+  }
+}
+
+const resolveSigningFunctions = ({
+  signAndSendTransactionFn,
+  signTransactionFn,
+  solanaWallet,
+  connection
+}) => {
+  let resolvedSignAndSend = typeof signAndSendTransactionFn === 'function' ? signAndSendTransactionFn : null
+  let resolvedSignTransaction = typeof signTransactionFn === 'function' ? signTransactionFn : null
+
+  let signAndSendSource = resolvedSignAndSend ? 'privy:signAndSendTransaction' : null
+  let signTransactionSource = resolvedSignTransaction ? 'privy:signTransaction' : null
+
+  if (!resolvedSignAndSend) {
+    const direct = bindWalletMethod(solanaWallet, ['signAndSendTransaction', 'signAndSend'])
+    if (direct) {
+      const adapted = adaptDirectSignAndSend(direct, connection)
+      if (adapted) {
+        resolvedSignAndSend = adapted
+        signAndSendSource = direct.source || 'wallet:signAndSendTransaction'
+      }
+    }
+  }
+
+  if (!resolvedSignTransaction) {
+    const direct = bindWalletMethod(solanaWallet, ['signTransaction', 'sign'])
+    if (direct) {
+      const adapted = adaptDirectSignTransaction(direct)
+      if (adapted) {
+        resolvedSignTransaction = adapted
+        signTransactionSource = direct.source || 'wallet:signTransaction'
+      }
+    }
+  }
+
+  return {
+    signAndSend: resolvedSignAndSend,
+    signTransaction: resolvedSignTransaction,
+    sources: {
+      signAndSend: signAndSendSource,
+      signTransaction: signTransactionSource
+    }
+  }
+}
+
 export const deductPaidRoomFee = async ({
   entryFeeUsd,
   feePercentage = DEFAULT_FEE_PERCENTAGE,
@@ -547,19 +710,32 @@ export const deductPaidRoomFee = async ({
 
   const privyErrors = []
 
-  if (typeof signAndSendTransactionFn === 'function') {
+  const { signAndSend: resolvedSignAndSend, signTransaction: resolvedSignTransaction, sources: signingSources } =
+    resolveSigningFunctions({
+      signAndSendTransactionFn,
+      signTransactionFn,
+      solanaWallet,
+      connection
+    })
+
+  if (signingSources.signAndSend || signingSources.signTransaction) {
+    logContext.signingSources = signingSources
+  }
+
+  if (resolvedSignAndSend) {
     const transaction = buildTransaction()
     try {
-      log.log?.('🔄 Processing Solana transaction via Privy signAndSendTransaction...', logContext)
-      const sendResult = await signAndSendTransactionFn(createPrivyRequest(transaction))
+      const label = signingSources.signAndSend || 'signAndSendTransaction'
+      log.log?.(`🔄 Processing Solana transaction via ${label}...`, logContext)
+      const sendResult = await resolvedSignAndSend(createPrivyRequest(transaction))
       const resolvedSignature = normaliseSignature(sendResult?.signature || sendResult)
 
       if (!resolvedSignature) {
-        throw new Error('Privy signAndSendTransaction did not return a transaction signature.')
+        throw new Error('signAndSendTransaction did not return a transaction signature.')
       }
 
       signature = resolvedSignature
-      signingMode = 'privy:signAndSendTransaction'
+      signingMode = label
       signedTransactionRaw = toUint8Array(sendResult?.rawTransaction) || null
 
       await connection.confirmTransaction(
@@ -571,14 +747,14 @@ export const deductPaidRoomFee = async ({
       )
 
       confirmationHandled = true
-      log.log?.('✅ Solana transaction confirmed via Privy signAndSendTransaction', {
+      log.log?.(`✅ Solana transaction confirmed via ${label}`, {
         ...logContext,
         signature,
         rpcEndpoint: endpoint
       })
     } catch (error) {
       privyErrors.push(error)
-      log.error?.('❌ Privy signAndSendTransaction failed.', error)
+      log.error?.(`❌ ${label} pathway failed.`, error)
       signature = undefined
       signingMode = undefined
       signedTransactionRaw = undefined
@@ -586,19 +762,20 @@ export const deductPaidRoomFee = async ({
     }
   }
 
-  if (!signature && typeof signTransactionFn === 'function') {
+  if (!signature && resolvedSignTransaction) {
     const transaction = buildTransaction()
     try {
-      log.log?.('🔄 Processing Solana transaction via Privy signTransaction...', logContext)
-      const signedResult = await signTransactionFn(createPrivyRequest(transaction))
+      const label = signingSources.signTransaction || 'signTransaction'
+      log.log?.(`🔄 Processing Solana transaction via ${label}...`, logContext)
+      const signedResult = await resolvedSignTransaction(createPrivyRequest(transaction))
       const { raw, signature: providedSignature } = normaliseSignedTransaction(signedResult)
 
       if (!raw) {
-        throw new Error('Privy signTransaction did not return signed transaction bytes.')
+        throw new Error('signTransaction did not return signed transaction bytes.')
       }
 
       signedTransactionRaw = raw
-      signingMode = 'privy:signTransaction'
+      signingMode = label
 
       const normalisedSignature = normaliseSignature(providedSignature)
       if (normalisedSignature) {
@@ -616,14 +793,14 @@ export const deductPaidRoomFee = async ({
         confirmationHandled = false
       }
 
-      log.log?.('✅ Solana transaction signed via Privy signTransaction', {
+      log.log?.(`✅ Solana transaction signed via ${label}`, {
         ...logContext,
         signature,
         rpcEndpoint: endpoint
       })
     } catch (error) {
       privyErrors.push(error)
-      log.error?.('❌ Privy signTransaction failed.', error)
+      log.error?.(`❌ ${label} pathway failed.`, error)
       signature = undefined
       signingMode = undefined
       signedTransactionRaw = undefined


### PR DESCRIPTION
## Summary
- guard the Privy Solana signing hooks on the client to avoid destructuring undefined responses
- add wallet-based fallbacks when Privy does not expose Solana signing helpers and improve related logging
- keep error messaging generic so failures surface regardless of which signing pathway was used

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e52aec3d2c8330be95b88cacfc1b66