### PR TITLE
Fix fee manager logging scope error

### DIFF
--- a/lib/paid/feeManager.js
+++ b/lib/paid/feeManager.js
@@ -724,8 +724,8 @@ export const deductPaidRoomFee = async ({
 
   if (resolvedSignAndSend) {
     const transaction = buildTransaction()
+    const label = signingSources.signAndSend || 'signAndSendTransaction'
     try {
-      const label = signingSources.signAndSend || 'signAndSendTransaction'
       log.log?.(`🔄 Processing Solana transaction via ${label}...`, logContext)
       const sendResult = await resolvedSignAndSend(createPrivyRequest(transaction))
       const resolvedSignature = normaliseSignature(sendResult?.signature || sendResult)
@@ -764,8 +764,8 @@ export const deductPaidRoomFee = async ({
 
   if (!signature && resolvedSignTransaction) {
     const transaction = buildTransaction()
+    const label = signingSources.signTransaction || 'signTransaction'
     try {
-      const label = signingSources.signTransaction || 'signTransaction'
       log.log?.(`🔄 Processing Solana transaction via ${label}...`, logContext)
       const signedResult = await resolvedSignTransaction(createPrivyRequest(transaction))
       const { raw, signature: providedSignature } = normaliseSignedTransaction(signedResult)


### PR DESCRIPTION
## Summary
- ensure the paid room fee signing flow defines its logging label outside the try block
- prevent ReferenceError when Solana transaction signing fails and the label is logged in the catch path

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e52fae9d8883308542925510d3cb33