### PR TITLE
Align Privy fee deduction flow with embedded wallet API

### DIFF
--- a/lib/paid/feeManager.js
+++ b/lib/paid/feeManager.js
@@ -320,6 +320,31 @@ const toUint8Array = (value) => {
   return null
 }
 
+const serialiseTransactionForWallet = (transaction) => {
+  if (!transaction) {
+    return null
+  }
+
+  if (transaction instanceof Uint8Array) {
+    return transaction
+  }
+
+  if (typeof transaction?.serialize === 'function') {
+    try {
+      const serialised = transaction.serialize({ requireAllSignatures: false, verifySignatures: false })
+      const bytes = toUint8Array(serialised)
+      if (bytes) {
+        return bytes
+      }
+    } catch (error) {
+      console.warn('⚠️ Failed to serialise transaction for Privy wallet signing:', error)
+    }
+  }
+
+  const fallback = toUint8Array(transaction)
+  return fallback || null
+}
+
 const normaliseSignedTransaction = (signedResult) => {
   if (!signedResult) {
     throw new Error('Wallet did not return a signed transaction.')
@@ -681,11 +706,28 @@ export const deductPaidRoomFee = async ({
 
   const walletIdentifier = resolvePrivyWalletIdentifier(solanaWallet, privyUser, walletAddress)
 
-  const createPrivyRequest = (transaction) => {
+  const createPrivyRequest = (transaction, { preferSerialized = false } = {}) => {
     const request = {
-      transaction,
       chain: chainIdentifier,
       options: preflightOptions
+    }
+
+    if (preferSerialized) {
+      const serialised = serialiseTransactionForWallet(transaction)
+      if (!serialised) {
+        throw new Error('Unable to serialise transaction for Privy wallet request.')
+      }
+
+      request.transaction = serialised
+
+      if (solanaWallet) {
+        request.wallet = solanaWallet
+        if (solanaWallet.address && !request.address) {
+          request.address = solanaWallet.address
+        }
+      }
+    } else {
+      request.transaction = transaction
     }
 
     if (walletIdentifier) {
@@ -725,9 +767,10 @@ export const deductPaidRoomFee = async ({
   if (resolvedSignAndSend) {
     const transaction = buildTransaction()
     const label = signingSources.signAndSend || 'signAndSendTransaction'
+    const preferSerialized = typeof label === 'string' && label.startsWith('privy:')
     try {
       log.log?.(`🔄 Processing Solana transaction via ${label}...`, logContext)
-      const sendResult = await resolvedSignAndSend(createPrivyRequest(transaction))
+      const sendResult = await resolvedSignAndSend(createPrivyRequest(transaction, { preferSerialized }))
       const resolvedSignature = normaliseSignature(sendResult?.signature || sendResult)
 
       if (!resolvedSignature) {
@@ -765,9 +808,10 @@ export const deductPaidRoomFee = async ({
   if (!signature && resolvedSignTransaction) {
     const transaction = buildTransaction()
     const label = signingSources.signTransaction || 'signTransaction'
+    const preferSerialized = typeof label === 'string' && label.startsWith('privy:')
     try {
       log.log?.(`🔄 Processing Solana transaction via ${label}...`, logContext)
-      const signedResult = await resolvedSignTransaction(createPrivyRequest(transaction))
+      const signedResult = await resolvedSignTransaction(createPrivyRequest(transaction, { preferSerialized }))
       const { raw, signature: providedSignature } = normaliseSignedTransaction(signedResult)
 
       if (!raw) {


### PR DESCRIPTION
## Summary
- add a serializer that prepares Solana transactions as Uint8Array payloads for Privy signing
- include the connected wallet metadata when invoking Privy sign-and-send/sign transaction helpers
- detect Privy hook pathways so only embedded wallets receive the serialized requests while direct wallets keep Transaction objects

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e543402dc48330876450b0fce0d7f4