### PR TITLE
Handle Privy signing when wallet object lacks methods

### DIFF
--- a/lib/paid/feeManager.js
+++ b/lib/paid/feeManager.js
@@ -446,6 +446,24 @@ const bindWalletMethod = (wallet, methodNames = []) => {
   return null
 }
 
+const walletHasDirectSigningCapability = (wallet) => {
+  if (!wallet || typeof wallet !== 'object') {
+    return false
+  }
+
+  if (
+    typeof wallet.signAndSendTransaction === 'function' ||
+    typeof wallet.signAndSend === 'function' ||
+    typeof wallet.signTransaction === 'function' ||
+    typeof wallet.sign === 'function'
+  ) {
+    return true
+  }
+
+  const nestedSigner = bindWalletMethod(wallet, ['signAndSendTransaction', 'signAndSend', 'signTransaction', 'sign'])
+  return Boolean(nestedSigner)
+}
+
 const adaptDirectSignAndSend = ({ method, context }, connection) => {
   if (typeof method !== 'function') {
     return null
@@ -719,15 +737,16 @@ export const deductPaidRoomFee = async ({
       }
 
       request.transaction = serialised
-
-      if (solanaWallet) {
-        request.wallet = solanaWallet
-        if (solanaWallet.address && !request.address) {
-          request.address = solanaWallet.address
-        }
-      }
     } else {
       request.transaction = transaction
+    }
+
+    if (solanaWallet?.address && !request.address) {
+      request.address = solanaWallet.address
+    }
+
+    if (preferSerialized && walletHasDirectSigningCapability(solanaWallet)) {
+      request.wallet = solanaWallet
     }
 
     if (walletIdentifier) {


### PR DESCRIPTION
## Summary
- add a capability check before binding Solana wallets to Privy signing requests
- avoid passing non-signing wallet objects so fee deductions can fall back to wallet identifiers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e54559fccc8330b34e352e5a34e361