### PR TITLE
Simplify Privy Solana transaction handling

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import { usePrivy, useWallets } from '@privy-io/react-auth'
-import { useFundWallet, useSignAndSendTransaction, useSignTransaction } from '@privy-io/react-auth/solana'
+import { useFundWallet, useSignAndSendTransaction } from '@privy-io/react-auth/solana'
 import { buildSolanaRpcEndpointList, calculatePaidRoomCosts, deductPaidRoomFee, SERVER_WALLET_ADDRESS } from '../lib/paid/feeManager'
 import ServerBrowserModal from '../components/ServerBrowserModalNew'
 
@@ -16,8 +16,6 @@ export default function TurfLootTactical() {
   const { fundWallet } = useFundWallet()
   const signAndSendTransactionResponse = useSignAndSendTransaction()
   const privySignAndSendTransaction = signAndSendTransactionResponse?.signAndSendTransaction
-  const signTransactionResponse = useSignTransaction()
-  const privySignTransaction = signTransactionResponse?.signTransaction
   
   // LOYALTY SYSTEM STATE
   const [loyaltyData, setLoyaltyData] = useState(null)
@@ -151,7 +149,6 @@ export default function TurfLootTactical() {
         serverWalletAddress: SERVER_WALLET_ADDRESS,
         logger: console,
         signAndSendTransactionFn: privySignAndSendTransaction,
-        signTransactionFn: privySignTransaction,
         solanaChain: SOLANA_CHAIN
       })
 

--- a/frontend/app/page.js
+++ b/frontend/app/page.js
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import { usePrivy, useWallets, useFundWallet } from '@privy-io/react-auth'
-import { useSignAndSendTransaction, useSignTransaction } from '@privy-io/react-auth/solana'
+import { useSignAndSendTransaction } from '@privy-io/react-auth/solana'
 import { buildSolanaRpcEndpointList, calculatePaidRoomCosts, deductPaidRoomFee, SERVER_WALLET_ADDRESS } from '../../lib/paid/feeManager'
 // NOTE: Should be '@privy-io/react-auth/solana' per docs, but causes compatibility issues
 import ServerBrowserModal from '../components/ServerBrowserModalNew'
@@ -17,8 +17,6 @@ export default function TurfLootTactical() {
   const { fundWallet } = useFundWallet()
   const signAndSendTransactionResponse = useSignAndSendTransaction()
   const privySignAndSendTransaction = signAndSendTransactionResponse?.signAndSendTransaction
-  const signTransactionResponse = useSignTransaction()
-  const privySignTransaction = signTransactionResponse?.signTransaction
   
   // LOYALTY SYSTEM STATE
   const [loyaltyData, setLoyaltyData] = useState(null)
@@ -151,7 +149,6 @@ export default function TurfLootTactical() {
         serverWalletAddress: SERVER_WALLET_ADDRESS,
         logger: console,
         signAndSendTransactionFn: privySignAndSendTransaction,
-        signTransactionFn: privySignTransaction,
         solanaChain: SOLANA_CHAIN
       })
 

--- a/lib/paid/feeManager.js
+++ b/lib/paid/feeManager.js
@@ -175,70 +175,6 @@ const normaliseSignature = (value) => {
   return null
 }
 
-const extractWalletIdentifier = (candidate) => {
-  if (!candidate) {
-    return null
-  }
-
-  if (typeof candidate === 'string' && candidate.trim()) {
-    return candidate.trim()
-  }
-
-  const candidateFields = ['walletId', 'id', 'address', 'accountAddress']
-
-  for (const field of candidateFields) {
-    const value = candidate?.[field]
-    if (typeof value === 'string' && value.trim()) {
-      return value.trim()
-    }
-  }
-
-  const publicKey = candidate?.publicKey
-  if (publicKey) {
-    if (typeof publicKey === 'string' && publicKey.trim()) {
-      return publicKey.trim()
-    }
-
-    if (typeof publicKey?.toBase58 === 'function') {
-      const derived = publicKey.toBase58()
-      if (derived) {
-        return derived
-      }
-    }
-
-    if (typeof publicKey?.toString === 'function') {
-      const derived = publicKey.toString()
-      if (derived) {
-        return derived
-      }
-    }
-  }
-
-  return null
-}
-
-const resolvePrivyWalletIdentifier = (solanaWallet, privyUser, fallbackAddress) => {
-  const candidates = [solanaWallet, solanaWallet?.walletClient, privyUser?.wallet]
-
-  if (Array.isArray(privyUser?.linkedAccounts)) {
-    candidates.push(...privyUser.linkedAccounts)
-  }
-
-  for (const candidate of candidates) {
-    const identifier = extractWalletIdentifier(candidate)
-    if (identifier) {
-      return identifier
-    }
-  }
-
-  const fallbackIdentifier = extractWalletIdentifier(fallbackAddress)
-  if (fallbackIdentifier) {
-    return fallbackIdentifier
-  }
-
-  return null
-}
-
 const decodeBase64 = (value) => {
   if (typeof value !== 'string' || !value.trim()) {
     return null
@@ -320,60 +256,6 @@ const toUint8Array = (value) => {
   return null
 }
 
-const serialiseTransactionForWallet = (transaction) => {
-  if (!transaction) {
-    return null
-  }
-
-  if (transaction instanceof Uint8Array) {
-    return transaction
-  }
-
-  if (typeof transaction?.serialize === 'function') {
-    try {
-      const serialised = transaction.serialize({ requireAllSignatures: false, verifySignatures: false })
-      const bytes = toUint8Array(serialised)
-      if (bytes) {
-        return bytes
-      }
-    } catch (error) {
-      console.warn('⚠️ Failed to serialise transaction for Privy wallet signing:', error)
-    }
-  }
-
-  const fallback = toUint8Array(transaction)
-  return fallback || null
-}
-
-const normaliseSignedTransaction = (signedResult) => {
-  if (!signedResult) {
-    throw new Error('Wallet did not return a signed transaction.')
-  }
-
-  const candidate =
-    signedResult?.signedTransaction || signedResult?.transaction || signedResult?.rawTransaction || signedResult
-
-  if (typeof candidate === 'string') {
-    return { signature: candidate }
-  }
-
-  if (candidate?.serialize) {
-    const serialised = candidate.serialize()
-    const raw = toUint8Array(serialised)
-    if (!raw) {
-      throw new Error('Unable to serialise signed transaction from wallet response.')
-    }
-    return { raw, transaction: candidate }
-  }
-
-  const rawCandidate = toUint8Array(candidate)
-  if (rawCandidate) {
-    return { raw: rawCandidate }
-  }
-
-  throw new Error('Wallet did not provide a serializable signed transaction.')
-}
-
 const connectToSolana = async (rpcEndpoints = []) => {
   const errors = []
   for (const endpoint of rpcEndpoints) {
@@ -390,55 +272,33 @@ const connectToSolana = async (rpcEndpoints = []) => {
   throw new Error(`Unable to connect to Solana RPC endpoint. Tried: ${errors.join(' | ')}`)
 }
 
-const WALLET_NESTED_KEYS = [
-  'wallet',
-  'walletClient',
-  'adapter',
-  'provider',
-  'signer',
-  'embeddedWallet',
-  'inner',
-  'delegate',
-  'link'
-]
-
-const bindWalletMethod = (wallet, methodNames = []) => {
+const resolveWalletSignAndSend = (wallet) => {
   if (!wallet || typeof wallet !== 'object') {
     return null
   }
 
-  const visited = new Set()
-  const queue = [{ candidate: wallet, path: 'wallet' }]
+  const candidates = [
+    { target: wallet, label: 'wallet' },
+    { target: wallet.wallet, label: 'wallet.wallet' },
+    { target: wallet.adapter, label: 'wallet.adapter' }
+  ]
 
-  const enqueue = (candidate, path) => {
-    if (!candidate || typeof candidate !== 'object') {
-      return
+  for (const { target, label } of candidates) {
+    if (!target) {
+      continue
     }
 
-    if (visited.has(candidate)) {
-      return
-    }
-
-    visited.add(candidate)
-    queue.push({ candidate, path })
-  }
-
-  while (queue.length > 0) {
-    const { candidate, path } = queue.shift()
-
-    for (const name of methodNames) {
-      if (typeof candidate?.[name] === 'function') {
-        return {
-          method: candidate[name],
-          context: candidate,
-          source: `${path}.${name}`
-        }
+    if (typeof target.signAndSendTransaction === 'function') {
+      return {
+        sender: target.signAndSendTransaction.bind(target),
+        source: `${label}.signAndSendTransaction`
       }
     }
 
-    for (const key of WALLET_NESTED_KEYS) {
-      if (candidate && typeof candidate[key] === 'object') {
-        enqueue(candidate[key], `${path}.${key}`)
+    if (typeof target.signAndSend === 'function') {
+      return {
+        sender: target.signAndSend.bind(target),
+        source: `${label}.signAndSend`
       }
     }
   }
@@ -446,129 +306,57 @@ const bindWalletMethod = (wallet, methodNames = []) => {
   return null
 }
 
-const walletHasDirectSigningCapability = (wallet) => {
-  if (!wallet || typeof wallet !== 'object') {
-    return false
-  }
-
-  if (
-    typeof wallet.signAndSendTransaction === 'function' ||
-    typeof wallet.signAndSend === 'function' ||
-    typeof wallet.signTransaction === 'function' ||
-    typeof wallet.sign === 'function'
-  ) {
-    return true
-  }
-
-  const nestedSigner = bindWalletMethod(wallet, ['signAndSendTransaction', 'signAndSend', 'signTransaction', 'sign'])
-  return Boolean(nestedSigner)
-}
-
-const adaptDirectSignAndSend = ({ method, context }, connection) => {
-  if (typeof method !== 'function') {
-    return null
-  }
-
-  return async (request) => {
-    const payload = request?.transaction || request
-
-    if (!payload) {
-      throw new Error('Transaction payload missing for wallet signAndSendTransaction call.')
-    }
-
-    const options = request?.options || (request?.preflightCommitment ? { preflightCommitment: request.preflightCommitment } : undefined)
-
-    try {
-      if (method.length >= 3) {
-        return await method.call(context, payload, connection, options)
-      }
-
-      if (method.length === 2) {
-        try {
-          return await method.call(context, payload, connection)
-        } catch (error) {
-          if (options !== undefined) {
-            return await method.call(context, payload, options)
-          }
-          throw error
-        }
-      }
-
-      if (options !== undefined) {
-        return await method.call(context, payload, options)
-      }
-
-      return await method.call(context, payload)
-    } catch (error) {
-      throw error
-    }
-  }
-}
-
-const adaptDirectSignTransaction = ({ method, context }) => {
-  if (typeof method !== 'function') {
-    return null
-  }
-
-  return async (request) => {
-    const payload = request?.transaction || request
-
-    if (!payload) {
-      throw new Error('Transaction payload missing for wallet signTransaction call.')
-    }
-
-    const options = request?.options
-
-    if (method.length >= 2 && options !== undefined) {
-      return await method.call(context, payload, options)
-    }
-
-    return await method.call(context, payload)
-  }
-}
-
-const resolveSigningFunctions = ({
-  signAndSendTransactionFn,
-  signTransactionFn,
+const sendTransactionWithPrivy = async ({
+  transaction,
+  chain,
   solanaWallet,
-  connection
+  signAndSendTransactionFn,
+  options
 }) => {
-  let resolvedSignAndSend = typeof signAndSendTransactionFn === 'function' ? signAndSendTransactionFn : null
-  let resolvedSignTransaction = typeof signTransactionFn === 'function' ? signTransactionFn : null
+  if (!transaction) {
+    throw new Error('A transaction is required before calling signAndSendTransaction.')
+  }
 
-  let signAndSendSource = resolvedSignAndSend ? 'privy:signAndSendTransaction' : null
-  let signTransactionSource = resolvedSignTransaction ? 'privy:signTransaction' : null
+  if (typeof transaction.serialize !== 'function') {
+    throw new Error('Provided transaction is not serializable.')
+  }
 
-  if (!resolvedSignAndSend) {
-    const direct = bindWalletMethod(solanaWallet, ['signAndSendTransaction', 'signAndSend'])
-    if (direct) {
-      const adapted = adaptDirectSignAndSend(direct, connection)
-      if (adapted) {
-        resolvedSignAndSend = adapted
-        signAndSendSource = direct.source || 'wallet:signAndSendTransaction'
-      }
+  const serialised = transaction.serialize({ requireAllSignatures: false, verifySignatures: false })
+  const transactionBytes = new Uint8Array(serialised)
+
+  const request = {
+    chain,
+    transaction: transactionBytes
+  }
+
+  if (options) {
+    request.options = options
+  }
+
+  if (solanaWallet?.address && !request.address) {
+    request.address = solanaWallet.address
+  }
+
+  const direct = resolveWalletSignAndSend(solanaWallet)
+  if (direct?.sender) {
+    const response = await direct.sender(request)
+    return {
+      signature: normaliseSignature(response?.signature || response),
+      rawTransaction: toUint8Array(response?.rawTransaction),
+      source: direct.source
     }
   }
 
-  if (!resolvedSignTransaction) {
-    const direct = bindWalletMethod(solanaWallet, ['signTransaction', 'sign'])
-    if (direct) {
-      const adapted = adaptDirectSignTransaction(direct)
-      if (adapted) {
-        resolvedSignTransaction = adapted
-        signTransactionSource = direct.source || 'wallet:signTransaction'
-      }
+  if (typeof signAndSendTransactionFn === 'function') {
+    const response = await signAndSendTransactionFn(request)
+    return {
+      signature: normaliseSignature(response?.signature || response),
+      rawTransaction: toUint8Array(response?.rawTransaction),
+      source: 'privy:signAndSendTransaction'
     }
   }
 
-  return {
-    signAndSend: resolvedSignAndSend,
-    signTransaction: resolvedSignTransaction,
-    sources: {
-      signAndSend: signAndSendSource,
-      signTransaction: signTransactionSource
-    }
-  }
+  throw new Error('No Privy signAndSendTransaction function available for the connected wallet.')
 }
 
 export const deductPaidRoomFee = async ({
@@ -588,7 +376,6 @@ export const deductPaidRoomFee = async ({
   memo,
   logger = console,
   signAndSendTransactionFn,
-  signTransactionFn,
   solanaChain
 }) => {
   const log = logger || console
@@ -717,45 +504,6 @@ export const deductPaidRoomFee = async ({
   const chainIdentifier = deriveSolanaChainIdentifier(solanaChain)
   const preflightOptions = { preflightCommitment: 'confirmed' }
 
-  let signature
-  let signedTransactionRaw
-  let signingMode
-  let confirmationHandled = false
-
-  const walletIdentifier = resolvePrivyWalletIdentifier(solanaWallet, privyUser, walletAddress)
-
-  const createPrivyRequest = (transaction, { preferSerialized = false } = {}) => {
-    const request = {
-      chain: chainIdentifier,
-      options: preflightOptions
-    }
-
-    if (preferSerialized) {
-      const serialised = serialiseTransactionForWallet(transaction)
-      if (!serialised) {
-        throw new Error('Unable to serialise transaction for Privy wallet request.')
-      }
-
-      request.transaction = serialised
-    } else {
-      request.transaction = transaction
-    }
-
-    if (solanaWallet?.address && !request.address) {
-      request.address = solanaWallet.address
-    }
-
-    if (preferSerialized && walletHasDirectSigningCapability(solanaWallet)) {
-      request.wallet = solanaWallet
-    }
-
-    if (walletIdentifier) {
-      request.walletId = walletIdentifier
-    }
-
-    return request
-  }
-
   const logContext = {
     entryLamports,
     feeLamports,
@@ -769,127 +517,47 @@ export const deductPaidRoomFee = async ({
     memoAttached: Boolean(memoPayload)
   }
 
-  const privyErrors = []
+  log.log?.('🔄 Sending Solana transaction via Privy...', logContext)
 
-  const { signAndSend: resolvedSignAndSend, signTransaction: resolvedSignTransaction, sources: signingSources } =
-    resolveSigningFunctions({
-      signAndSendTransactionFn,
-      signTransactionFn,
+  let signature
+  let rawTransactionBytes = null
+  let signingMode = null
+
+  try {
+    const transaction = buildTransaction()
+    const sendResult = await sendTransactionWithPrivy({
+      transaction,
+      chain: chainIdentifier,
       solanaWallet,
-      connection
+      signAndSendTransactionFn,
+      options: preflightOptions
     })
 
-  if (signingSources.signAndSend || signingSources.signTransaction) {
-    logContext.signingSources = signingSources
-  }
+    signature = sendResult.signature || null
+    rawTransactionBytes = sendResult.rawTransaction || null
+    signingMode = sendResult.source || 'privy:signAndSendTransaction'
 
-  if (resolvedSignAndSend) {
-    const transaction = buildTransaction()
-    const label = signingSources.signAndSend || 'signAndSendTransaction'
-    const preferSerialized = typeof label === 'string' && label.startsWith('privy:')
-    try {
-      log.log?.(`🔄 Processing Solana transaction via ${label}...`, logContext)
-      const sendResult = await resolvedSignAndSend(createPrivyRequest(transaction, { preferSerialized }))
-      const resolvedSignature = normaliseSignature(sendResult?.signature || sendResult)
-
-      if (!resolvedSignature) {
-        throw new Error('signAndSendTransaction did not return a transaction signature.')
-      }
-
-      signature = resolvedSignature
-      signingMode = label
-      signedTransactionRaw = toUint8Array(sendResult?.rawTransaction) || null
-
-      await connection.confirmTransaction(
-        {
-          signature,
-          ...latestBlockhash
-        },
-        'confirmed'
-      )
-
-      confirmationHandled = true
-      log.log?.(`✅ Solana transaction confirmed via ${label}`, {
-        ...logContext,
-        signature,
-        rpcEndpoint: endpoint
-      })
-    } catch (error) {
-      privyErrors.push(error)
-      log.error?.(`❌ ${label} pathway failed.`, error)
-      signature = undefined
-      signingMode = undefined
-      signedTransactionRaw = undefined
-      confirmationHandled = false
+    if (!signature) {
+      throw new Error('Privy wallet did not return a transaction signature.')
     }
-  }
-
-  if (!signature && resolvedSignTransaction) {
-    const transaction = buildTransaction()
-    const label = signingSources.signTransaction || 'signTransaction'
-    const preferSerialized = typeof label === 'string' && label.startsWith('privy:')
-    try {
-      log.log?.(`🔄 Processing Solana transaction via ${label}...`, logContext)
-      const signedResult = await resolvedSignTransaction(createPrivyRequest(transaction, { preferSerialized }))
-      const { raw, signature: providedSignature } = normaliseSignedTransaction(signedResult)
-
-      if (!raw) {
-        throw new Error('signTransaction did not return signed transaction bytes.')
-      }
-
-      signedTransactionRaw = raw
-      signingMode = label
-
-      const normalisedSignature = normaliseSignature(providedSignature)
-      if (normalisedSignature) {
-        signature = normalisedSignature
-        await connection.confirmTransaction(
-          {
-            signature,
-            ...latestBlockhash
-          },
-          'confirmed'
-        )
-        confirmationHandled = true
-      } else {
-        signature = await connection.sendRawTransaction(raw, preflightOptions)
-        confirmationHandled = false
-      }
-
-      log.log?.(`✅ Solana transaction signed via ${label}`, {
-        ...logContext,
-        signature,
-        rpcEndpoint: endpoint
-      })
-    } catch (error) {
-      privyErrors.push(error)
-      log.error?.(`❌ ${label} pathway failed.`, error)
-      signature = undefined
-      signingMode = undefined
-      signedTransactionRaw = undefined
-      confirmationHandled = false
-    }
-  }
-
-  if (!signature) {
-    const errorMessages = privyErrors.map((error) => error?.message || error).filter(Boolean)
-    const reason = errorMessages.length ? ` Reason: ${errorMessages.join(' | ')}` : ''
-    throw new Error(`Unable to access signing capabilities for the connected Solana wallet.${reason}`)
-  }
-
-  if (!confirmationHandled) {
-    log.log?.('📝 Transaction submitted. Awaiting confirmation…', signature)
 
     await connection.confirmTransaction(
       {
         signature,
-        blockhash: latestBlockhash.blockhash,
-        lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
+        ...latestBlockhash
       },
       'confirmed'
     )
 
-    log.log?.('✅ Solana transaction confirmed!')
+    log.log?.('✅ Solana transaction confirmed via Privy', {
+      ...logContext,
+      signature,
+      rpcEndpoint: endpoint,
+      signingMode
+    })
+  } catch (error) {
+    log.error?.('❌ Failed to process Solana transaction with Privy.', error)
+    throw error
   }
 
   return {
@@ -904,7 +572,7 @@ export const deductPaidRoomFee = async ({
     prizeVault,
     feeVault,
     memo: memo ?? memoPayload,
-    rawTransaction: signedTransactionRaw,
+    rawTransaction: rawTransactionBytes,
     signingMode
   }
 }


### PR DESCRIPTION
## Summary
- simplify the Solana fee deduction flow to use Privy wallet signAndSendTransaction per the official integration guidance
- remove unused Privy signTransaction plumbing in the Next.js entry points so that only the rebuilt transaction sender is wired up

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e5c27864ec8330b59c6cb5a6c8200b