### PR TITLE
Fix direct wallet invocation in Privy Solana fallback

### DIFF
--- a/lib/paid/feeManager.js
+++ b/lib/paid/feeManager.js
@@ -339,7 +339,10 @@ const sendTransactionWithPrivy = async ({
 
   const direct = resolveWalletSignAndSend(solanaWallet)
   if (direct?.sender) {
-    const response = await direct.sender(request)
+    const response =
+      request.options !== undefined
+        ? await direct.sender(transaction, request.options)
+        : await direct.sender(transaction)
     return {
       signature: normaliseSignature(response?.signature || response),
       rawTransaction: toUint8Array(response?.rawTransaction),


### PR DESCRIPTION
## Summary
- correct the direct wallet fallback in the Privy transaction helper so it forwards the Transaction instead of the full request object

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5c4d8955483308ab302e0d8722b4d