### PR TITLE
Improve Privy fallback wallet resolution

### DIFF
--- a/lib/paid/feeManager.js
+++ b/lib/paid/feeManager.js
@@ -272,21 +272,38 @@ const connectToSolana = async (rpcEndpoints = []) => {
   throw new Error(`Unable to connect to Solana RPC endpoint. Tried: ${errors.join(' | ')}`)
 }
 
-const resolveWalletSignAndSend = (wallet) => {
-  if (!wallet || typeof wallet !== 'object') {
-    return null
+const resolveWalletSignAndSend = (...wallets) => {
+  const visited = new Set()
+  const queue = []
+
+  const enqueue = (target, label) => {
+    if (!target || (typeof target !== 'object' && typeof target !== 'function')) {
+      return
+    }
+
+    if (visited.has(target)) {
+      return
+    }
+
+    visited.add(target)
+    queue.push({ target, label })
   }
 
-  const candidates = [
-    { target: wallet, label: 'wallet' },
-    { target: wallet.wallet, label: 'wallet.wallet' },
-    { target: wallet.adapter, label: 'wallet.adapter' }
-  ]
+  wallets.forEach((wallet, index) => {
+    enqueue(wallet, `wallet[${index}]`)
+  })
 
-  for (const { target, label } of candidates) {
-    if (!target) {
-      continue
+  if (typeof globalThis !== 'undefined') {
+    enqueue(globalThis.solana, 'globalThis.solana')
+    if (globalThis.phantom?.solana) {
+      enqueue(globalThis.phantom.solana, 'globalThis.phantom.solana')
     }
+  }
+
+  const nestedKeys = ['wallet', 'adapter', 'walletClient', 'provider', 'client', 'anchorProvider', 'solana']
+
+  while (queue.length > 0) {
+    const { target, label } = queue.shift()
 
     if (typeof target.signAndSendTransaction === 'function') {
       return {
@@ -301,6 +318,22 @@ const resolveWalletSignAndSend = (wallet) => {
         source: `${label}.signAndSend`
       }
     }
+
+    if (Array.isArray(target)) {
+      target.forEach((item, index) => enqueue(item, `${label}[${index}]`))
+      continue
+    }
+
+    for (const key of nestedKeys) {
+      const nested = target?.[key]
+      if (nested) {
+        enqueue(nested, `${label}.${key}`)
+      }
+    }
+
+    if (target?.phantom?.solana) {
+      enqueue(target.phantom.solana, `${label}.phantom.solana`)
+    }
   }
 
   return null
@@ -310,6 +343,7 @@ const sendTransactionWithPrivy = async ({
   transaction,
   chain,
   solanaWallet,
+  privyUser,
   signAndSendTransactionFn,
   options
 }) => {
@@ -333,13 +367,67 @@ const sendTransactionWithPrivy = async ({
     request.options = options
   }
 
-  if (solanaWallet?.address && !request.address) {
-    request.address = solanaWallet.address
+  const linkedSolanaWallets = Array.isArray(privyUser?.linkedAccounts)
+    ? privyUser.linkedAccounts.filter((account) => account?.chainType === 'solana')
+    : []
+
+  const resolveAddress = (candidate) => {
+    if (!candidate || typeof candidate !== 'object') {
+      return null
+    }
+
+    if (typeof candidate.address === 'string' && candidate.address) {
+      return candidate.address
+    }
+
+    if (typeof candidate.publicKey === 'string' && candidate.publicKey) {
+      return candidate.publicKey
+    }
+
+    if (candidate.publicKey?.toBase58) {
+      try {
+        const asBase58 = candidate.publicKey.toBase58()
+        if (asBase58) {
+          return asBase58
+        }
+      } catch (error) {
+        // ignore - unable to derive address from public key
+      }
+    }
+
+    if (candidate.publicKey?.toString) {
+      try {
+        const asString = candidate.publicKey.toString()
+        if (asString) {
+          return asString
+        }
+      } catch (error) {
+        // ignore - unable to derive address from public key
+      }
+    }
+
+    return null
   }
 
-  const direct = resolveWalletSignAndSend(solanaWallet)
+  const candidateAddress =
+    resolveAddress(solanaWallet) ||
+    resolveAddress(privyUser?.wallet) ||
+    linkedSolanaWallets.map(resolveAddress).find(Boolean)
+
+  if (candidateAddress && !request.address) {
+    request.address = candidateAddress
+  }
+
+  const direct = resolveWalletSignAndSend(
+    solanaWallet,
+    privyUser?.wallet,
+    ...linkedSolanaWallets
+  )
   if (direct?.sender) {
-    const response = await direct.sender(request)
+    const response =
+      request.options !== undefined
+        ? await direct.sender(transaction, request.options)
+        : await direct.sender(transaction)
     return {
       signature: normaliseSignature(response?.signature || response),
       rawTransaction: toUint8Array(response?.rawTransaction),
@@ -529,6 +617,7 @@ export const deductPaidRoomFee = async ({
       transaction,
       chain: chainIdentifier,
       solanaWallet,
+      privyUser,
       signAndSendTransactionFn,
       options: preflightOptions
     })


### PR DESCRIPTION
## Summary
- broaden the direct wallet discovery logic to crawl nested wallet objects and global Solana providers before falling back to Privy signing
- include Privy user context so linked Solana accounts contribute addresses and signing capabilities for direct execution

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5c4d8955483308ab302e0d8722b4d