### PR TITLE
Remove Helius usage from paid room fee transfers

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -52,9 +52,7 @@ export default function TurfLootTactical() {
         network: process.env.NEXT_PUBLIC_SOLANA_NETWORK || 'mainnet-beta',
         primary: process.env.NEXT_PUBLIC_SOLANA_RPC,
         list: process.env.NEXT_PUBLIC_SOLANA_RPC_LIST,
-        fallbacks: process.env.NEXT_PUBLIC_SOLANA_RPC_FALLBACKS,
-        heliusRpcUrl: process.env.NEXT_PUBLIC_HELIUS_RPC || process.env.HELIUS_RPC_URL,
-        heliusApiKey: process.env.NEXT_PUBLIC_HELIUS_API_KEY || process.env.HELIUS_API_KEY
+        fallbacks: process.env.NEXT_PUBLIC_SOLANA_RPC_FALLBACKS
       }),
     []
   )
@@ -130,6 +128,14 @@ export default function TurfLootTactical() {
       return {
         success: false,
         error: 'No Solana wallet available for fee deduction. Please connect a wallet and try again.',
+        costs
+      }
+    }
+
+    if (typeof privySignAndSendTransaction !== 'function') {
+      return {
+        success: false,
+        error: 'Privy transaction signing is not available. Please reconnect your wallet and try again.',
         costs
       }
     }

--- a/frontend/app/page.js
+++ b/frontend/app/page.js
@@ -53,9 +53,7 @@ export default function TurfLootTactical() {
         network: process.env.NEXT_PUBLIC_SOLANA_NETWORK || 'mainnet-beta',
         primary: process.env.NEXT_PUBLIC_SOLANA_RPC,
         list: process.env.NEXT_PUBLIC_SOLANA_RPC_LIST,
-        fallbacks: process.env.NEXT_PUBLIC_SOLANA_RPC_FALLBACKS,
-        heliusRpcUrl: process.env.NEXT_PUBLIC_HELIUS_RPC || process.env.HELIUS_RPC_URL,
-        heliusApiKey: process.env.NEXT_PUBLIC_HELIUS_API_KEY || process.env.HELIUS_API_KEY
+        fallbacks: process.env.NEXT_PUBLIC_SOLANA_RPC_FALLBACKS
       }),
     []
   )
@@ -130,6 +128,14 @@ export default function TurfLootTactical() {
       return {
         success: false,
         error: 'No Solana wallet available for fee deduction. Please connect a wallet and try again.',
+        costs
+      }
+    }
+
+    if (typeof privySignAndSendTransaction !== 'function') {
+      return {
+        success: false,
+        error: 'Privy transaction signing is not available. Please reconnect your wallet and try again.',
         costs
       }
     }

--- a/lib/paid/feeManager.js
+++ b/lib/paid/feeManager.js
@@ -51,53 +51,13 @@ const normaliseList = (value) =>
     .map((entry) => entry.trim())
     .filter(Boolean)
 
-const resolveEnv = (key) => {
-  if (typeof process === 'undefined') {
-    return undefined
-  }
-  return process?.env?.[key]
-}
-
-const normaliseHeliusNetwork = (network) => {
-  if (!network) {
-    return 'mainnet'
-  }
-
-  const trimmed = network.trim().toLowerCase()
-
-  if (trimmed === 'mainnet-beta' || trimmed === 'mainnet') {
-    return 'mainnet'
-  }
-  if (trimmed === 'devnet') {
-    return 'devnet'
-  }
-  if (trimmed === 'testnet') {
-    return 'testnet'
-  }
-
-  return trimmed
-}
-
 export const buildSolanaRpcEndpointList = ({
   network = 'mainnet-beta',
   primary,
   list = '',
-  fallbacks = '',
-  heliusApiKey,
-  heliusRpcUrl
+  fallbacks = ''
 } = {}) => {
   const endpoints = []
-
-  const envHeliusRpcUrl = heliusRpcUrl || resolveEnv('NEXT_PUBLIC_HELIUS_RPC_URL') || resolveEnv('HELIUS_RPC_URL')
-  const envHeliusApiKey = heliusApiKey || resolveEnv('NEXT_PUBLIC_HELIUS_API_KEY') || resolveEnv('HELIUS_API_KEY')
-
-  if (envHeliusRpcUrl) {
-    endpoints.push(envHeliusRpcUrl.trim())
-  } else if (envHeliusApiKey) {
-    const heliusNetwork = normaliseHeliusNetwork(network)
-    const heliusEndpoint = `https://${heliusNetwork}.helius-rpc.com/?api-key=${envHeliusApiKey.trim()}`
-    endpoints.push(heliusEndpoint)
-  }
 
   if (primary) {
     endpoints.push(primary.trim())
@@ -272,40 +232,6 @@ const connectToSolana = async (rpcEndpoints = []) => {
   throw new Error(`Unable to connect to Solana RPC endpoint. Tried: ${errors.join(' | ')}`)
 }
 
-const resolveWalletSignAndSend = (wallet) => {
-  if (!wallet || typeof wallet !== 'object') {
-    return null
-  }
-
-  const candidates = [
-    { target: wallet, label: 'wallet' },
-    { target: wallet.wallet, label: 'wallet.wallet' },
-    { target: wallet.adapter, label: 'wallet.adapter' }
-  ]
-
-  for (const { target, label } of candidates) {
-    if (!target) {
-      continue
-    }
-
-    if (typeof target.signAndSendTransaction === 'function') {
-      return {
-        sender: target.signAndSendTransaction.bind(target),
-        source: `${label}.signAndSendTransaction`
-      }
-    }
-
-    if (typeof target.signAndSend === 'function') {
-      return {
-        sender: target.signAndSend.bind(target),
-        source: `${label}.signAndSend`
-      }
-    }
-  }
-
-  return null
-}
-
 const sendTransactionWithPrivy = async ({
   transaction,
   chain,
@@ -337,26 +263,16 @@ const sendTransactionWithPrivy = async ({
     request.address = solanaWallet.address
   }
 
-  const direct = resolveWalletSignAndSend(solanaWallet)
-  if (direct?.sender) {
-    const response = await direct.sender(request)
-    return {
-      signature: normaliseSignature(response?.signature || response),
-      rawTransaction: toUint8Array(response?.rawTransaction),
-      source: direct.source
-    }
+  if (typeof signAndSendTransactionFn !== 'function') {
+    throw new Error('No Privy signAndSendTransaction function available for the connected wallet.')
   }
 
-  if (typeof signAndSendTransactionFn === 'function') {
-    const response = await signAndSendTransactionFn(request)
-    return {
-      signature: normaliseSignature(response?.signature || response),
-      rawTransaction: toUint8Array(response?.rawTransaction),
-      source: 'privy:signAndSendTransaction'
-    }
+  const response = await signAndSendTransactionFn(request)
+  return {
+    signature: normaliseSignature(response?.signature || response),
+    rawTransaction: toUint8Array(response?.rawTransaction),
+    source: 'privy:signAndSendTransaction'
   }
-
-  throw new Error('No Privy signAndSendTransaction function available for the connected wallet.')
 }
 
 export const deductPaidRoomFee = async ({


### PR DESCRIPTION
## Summary
- stop deriving paid room fee RPC endpoints from Helius configuration and rely on standard Solana URLs
- require Privy to sign and submit paid room transfers instead of falling back to local wallet helpers
- guard the paid room workflow in the app against missing Privy signAndSend support

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5c942990c8330880f3c585c58d488