### PR TITLE
Restore Helius transaction fetching for Privy wallets

### DIFF
--- a/app/api/wallet/transactions/route.js
+++ b/app/api/wallet/transactions/route.js
@@ -1,4 +1,222 @@
 import { NextResponse } from 'next/server'
+import { MongoClient } from 'mongodb'
+import jwt from 'jsonwebtoken'
+
+const JWT_SECRET = process.env.JWT_SECRET || 'turfloot-secret-key-change-in-production'
+const MONGO_URL = process.env.MONGO_URL || 'mongodb://localhost:27017/turfloot'
+const HELIUS_API_KEY =
+  process.env.HELIUS_API_KEY ||
+  process.env.NEXT_PUBLIC_HELIUS_API_KEY ||
+  process.env.HELIUS_RPC_API_KEY ||
+  '9ce7937c-f2a5-4759-8d79-dd8f9ca63fa5'
+const HELIUS_REST_BASE = process.env.HELIUS_REST_BASE || 'https://api.helius.xyz/v0'
+
+let client = null
+
+async function getDb() {
+  if (!client) {
+    try {
+      console.log('🔗 Connecting to MongoDB for wallet transactions')
+      client = new MongoClient(MONGO_URL, {
+        serverSelectionTimeoutMS: 5000,
+        connectTimeoutMS: 10000,
+        maxPoolSize: 10,
+      })
+      await client.connect()
+      console.log('✅ MongoDB connected successfully for transactions')
+    } catch (error) {
+      console.error('❌ MongoDB connection failed for transactions:', error)
+      throw error
+    }
+  }
+  return client.db('turfloot_db')
+}
+
+function decodeTestingToken(token) {
+  try {
+    const encoded = token.substring(8)
+    const payload = JSON.parse(Buffer.from(encoded, 'base64').toString('utf-8'))
+    console.log('🧪 Testing token payload (transactions):', payload)
+    return payload
+  } catch (error) {
+    console.error('❌ Error parsing testing token for transactions:', error)
+    return null
+  }
+}
+
+function decodeAuthToken(token) {
+  if (!token) {
+    return { type: 'guest' }
+  }
+
+  if (token.startsWith('testing-')) {
+    const payload = decodeTestingToken(token)
+    if (!payload) {
+      return { type: 'guest' }
+    }
+    return { type: 'testing', payload }
+  }
+
+  try {
+    const decoded = jwt.verify(token, JWT_SECRET)
+    console.log('✅ JWT authenticated user for transactions:', decoded.userId || decoded.id)
+    return { type: 'jwt', user: decoded }
+  } catch (jwtError) {
+    console.log('⚠️ JWT verification failed for transactions, checking Privy token:', jwtError.message)
+
+    try {
+      const base64Payload = token.split('.')[1]
+      if (!base64Payload) {
+        throw new Error('Invalid Privy token format')
+      }
+
+      const decoded = JSON.parse(Buffer.from(base64Payload, 'base64').toString('utf-8'))
+      console.log('🔍 Privy token payload (transactions):', {
+        userId: decoded.sub,
+        email: decoded.email,
+        walletAddress: decoded.wallet?.address,
+      })
+
+      const authenticatedUser = {
+        id: decoded.sub,
+        privy_id: decoded.sub,
+        email: decoded.email,
+        jwt_wallet_address: decoded.wallet?.address,
+        isPrivyAuth: true,
+      }
+
+      console.log('✅ Privy token authenticated for transactions:', authenticatedUser.id)
+      return { type: 'privy', user: authenticatedUser }
+    } catch (privyError) {
+      console.log('⚠️ Privy token parsing also failed for transactions:', privyError.message)
+      return { type: 'guest' }
+    }
+  }
+}
+
+function findWalletAddress(user, authenticatedUser) {
+  const walletSources = [
+    authenticatedUser?.jwt_wallet_address,
+    user?.wallet_address,
+    user?.embedded_wallet_address,
+    user?.privy_wallet_address,
+  ]
+
+  const walletAddress = walletSources.find((addr) => addr && addr !== 'Not connected')
+  console.log(`🔍 Wallet address resolution (transactions): ${walletAddress || 'No wallet found'}`)
+  return walletAddress
+}
+
+function buildTestingTransactions(payload) {
+  const walletAddress = payload.wallet_address || 'F7zDew151bya8KatZiHF6EXDBi8DVNJvrLE619vwypvG'
+  const now = Date.now()
+
+  return [
+    {
+      signature: 'TEST-HELIUS-IN-1',
+      description: 'Test SOL deposit',
+      timestamp: new Date(now - 60_000).toISOString(),
+      sol_amount: 0.25,
+      usd_amount: 40.0,
+      direction: 'incoming',
+      status: 'confirmed',
+      source: 'testing',
+    },
+    {
+      signature: 'TEST-HELIUS-OUT-1',
+      description: 'Test SOL withdrawal',
+      timestamp: new Date(now - 120_000).toISOString(),
+      sol_amount: 0.1,
+      usd_amount: 16.0,
+      direction: 'outgoing',
+      status: 'confirmed',
+      source: 'testing',
+    },
+  ].map((tx, index) => ({
+    ...tx,
+    index,
+    wallet_address: walletAddress,
+  }))
+}
+
+function lamportsToSol(lamports) {
+  return parseFloat(((lamports || 0) / 1e9).toFixed(6))
+}
+
+function normaliseHeliusTransactions(rawTransactions, walletAddress) {
+  if (!Array.isArray(rawTransactions)) {
+    return []
+  }
+
+  const lowerWallet = walletAddress.toLowerCase()
+
+  return rawTransactions.map((tx, index) => {
+    const nativeTransfers = Array.isArray(tx.nativeTransfers) ? tx.nativeTransfers : []
+
+    const netLamports = nativeTransfers.reduce((total, transfer) => {
+      const amount = Number(transfer.amount || 0)
+      if (!amount) {
+        return total
+      }
+
+      const toAddress = (transfer.toUserAccount || transfer.to || '').toLowerCase()
+      const fromAddress = (transfer.fromUserAccount || transfer.from || '').toLowerCase()
+
+      if (toAddress === lowerWallet) {
+        return total + amount
+      }
+      if (fromAddress === lowerWallet) {
+        return total - amount
+      }
+
+      return total
+    }, 0)
+
+    const solAmount = lamportsToSol(Math.abs(netLamports))
+    const direction = netLamports >= 0 ? 'incoming' : 'outgoing'
+    const usdAmount = parseFloat((solAmount * 160).toFixed(2))
+    const timestamp = tx.timestamp ? new Date(tx.timestamp * 1000).toISOString() : new Date().toISOString()
+
+    return {
+      signature: tx.signature,
+      description: tx.description || tx.type || 'Solana transaction',
+      timestamp,
+      sol_amount: solAmount,
+      usd_amount: usdAmount,
+      direction,
+      status: tx.status || 'confirmed',
+      source: 'helius',
+      nativeTransfers,
+      index,
+    }
+  })
+}
+
+async function fetchHeliusTransactions(walletAddress) {
+  if (!HELIUS_API_KEY || !walletAddress) {
+    console.log('⚠️ Missing Helius API key or wallet address for transactions')
+    return []
+  }
+
+  try {
+    const heliusUrl = `${HELIUS_REST_BASE}/addresses/${walletAddress}/transactions?api-key=${HELIUS_API_KEY}&limit=20`
+    console.log('🌐 Fetching Helius transactions from:', heliusUrl)
+
+    const response = await fetch(heliusUrl, { method: 'GET' })
+    if (!response.ok) {
+      console.warn('⚠️ Helius transactions response not OK:', response.status, response.statusText)
+      return []
+    }
+
+    const data = await response.json()
+    const normalised = normaliseHeliusTransactions(data, walletAddress)
+    console.log(`✅ Retrieved ${normalised.length} Helius transactions for wallet ${walletAddress}`)
+    return normalised
+  } catch (error) {
+    console.error('❌ Error fetching transactions from Helius:', error)
+    return []
+  }
+}
 
 export async function GET(request) {
   const corsHeaders = {
@@ -8,44 +226,96 @@ export async function GET(request) {
   }
 
   try {
-    console.log('🎯 WALLET TRANSACTIONS ENDPOINT REACHED!')
-    
-    // Get Authorization header
     const authHeader = request.headers.get('authorization')
-    let token = null
-    
-    if (authHeader && authHeader.startsWith('Bearer ')) {
-      token = authHeader.substring(7)
-    }
-    
+    const token = authHeader && authHeader.startsWith('Bearer ')
+      ? authHeader.substring(7)
+      : null
+
     console.log('🔍 Wallet transactions request - Token present:', !!token)
-    
-    // For now, return empty transactions array since we're in testing phase
-    // In production, this would fetch real blockchain transactions using Helius API
-    const transactionsResponse = {
-      transactions: [],
-      total_count: 0,
-      wallet_address: 'F7zDew151bya8KatZiHF6EXDBi8DVNJvrLE619vwypvG', // Default for testing
-      timestamp: new Date().toISOString()
+
+    const authInfo = decodeAuthToken(token)
+
+    if (authInfo.type === 'testing') {
+      const transactions = buildTestingTransactions(authInfo.payload)
+      const responsePayload = {
+        transactions,
+        total_count: transactions.length,
+        wallet_address: transactions[0]?.wallet_address || authInfo.payload.wallet_address,
+        helius_enabled: true,
+        privy_authenticated: false,
+        timestamp: new Date().toISOString(),
+        source: 'testing',
+      }
+
+      console.log('🧪 Returning testing transactions response:', responsePayload)
+      return NextResponse.json(responsePayload, { headers: corsHeaders })
     }
-    
-    console.log('📊 Returning transactions data:', transactionsResponse)
-    return NextResponse.json(transactionsResponse, { headers: corsHeaders })
-    
+
+    if (authInfo.type === 'guest') {
+      console.log('🎭 Guest request for transactions - returning empty list')
+      return NextResponse.json({
+        transactions: [],
+        total_count: 0,
+        wallet_address: 'Not connected',
+        helius_enabled: !!HELIUS_API_KEY,
+        privy_authenticated: false,
+        timestamp: new Date().toISOString(),
+      }, { headers: corsHeaders })
+    }
+
+    const authenticatedUser = authInfo.user
+    const db = await getDb()
+    const users = db.collection('users')
+
+    const user = await users.findOne({
+      $or: [
+        { id: authenticatedUser.id },
+        { privy_id: authenticatedUser.privy_id || authenticatedUser.id },
+      ],
+    })
+
+    const walletAddress = findWalletAddress(user, authenticatedUser)
+
+    if (!walletAddress) {
+      console.log('⚠️ No wallet address found for authenticated user - returning empty transactions')
+      return NextResponse.json({
+        transactions: [],
+        total_count: 0,
+        wallet_address: 'Not connected',
+        helius_enabled: !!HELIUS_API_KEY,
+        privy_authenticated: Boolean(authenticatedUser?.isPrivyAuth),
+        timestamp: new Date().toISOString(),
+      }, { headers: corsHeaders })
+    }
+
+    const transactions = await fetchHeliusTransactions(walletAddress)
+
+    const responsePayload = {
+      transactions,
+      total_count: transactions.length,
+      wallet_address: walletAddress,
+      helius_enabled: !!HELIUS_API_KEY,
+      privy_authenticated: Boolean(authenticatedUser?.isPrivyAuth),
+      timestamp: new Date().toISOString(),
+      source: transactions.length ? 'helius' : 'helius-empty',
+    }
+
+    console.log('📊 Returning transactions data:', responsePayload)
+    return NextResponse.json(responsePayload, { headers: corsHeaders })
   } catch (error) {
     console.error('❌ Error in wallet transactions endpoint:', error)
-    return NextResponse.json({ 
+    return NextResponse.json({
       error: 'Internal Server Error',
       transactions: [],
-      total_count: 0
-    }, { 
-      status: 500, 
-      headers: corsHeaders 
+      total_count: 0,
+    }, {
+      status: 500,
+      headers: corsHeaders,
     })
   }
 }
 
-export async function OPTIONS(request) {
+export async function OPTIONS() {
   return new NextResponse(null, {
     status: 200,
     headers: {

--- a/frontend/app/api/wallet/transactions/route.js
+++ b/frontend/app/api/wallet/transactions/route.js
@@ -1,4 +1,222 @@
 import { NextResponse } from 'next/server'
+import { MongoClient } from 'mongodb'
+import jwt from 'jsonwebtoken'
+
+const JWT_SECRET = process.env.JWT_SECRET || 'turfloot-secret-key-change-in-production'
+const MONGO_URL = process.env.MONGO_URL || 'mongodb://localhost:27017/turfloot'
+const HELIUS_API_KEY =
+  process.env.HELIUS_API_KEY ||
+  process.env.NEXT_PUBLIC_HELIUS_API_KEY ||
+  process.env.HELIUS_RPC_API_KEY ||
+  '9ce7937c-f2a5-4759-8d79-dd8f9ca63fa5'
+const HELIUS_REST_BASE = process.env.HELIUS_REST_BASE || 'https://api.helius.xyz/v0'
+
+let client = null
+
+async function getDb() {
+  if (!client) {
+    try {
+      console.log('🔗 Connecting to MongoDB for wallet transactions (frontend copy)')
+      client = new MongoClient(MONGO_URL, {
+        serverSelectionTimeoutMS: 5000,
+        connectTimeoutMS: 10000,
+        maxPoolSize: 10,
+      })
+      await client.connect()
+      console.log('✅ MongoDB connected successfully for transactions (frontend copy)')
+    } catch (error) {
+      console.error('❌ MongoDB connection failed for transactions (frontend copy):', error)
+      throw error
+    }
+  }
+  return client.db('turfloot_db')
+}
+
+function decodeTestingToken(token) {
+  try {
+    const encoded = token.substring(8)
+    const payload = JSON.parse(Buffer.from(encoded, 'base64').toString('utf-8'))
+    console.log('🧪 Testing token payload (frontend transactions):', payload)
+    return payload
+  } catch (error) {
+    console.error('❌ Error parsing testing token for transactions (frontend copy):', error)
+    return null
+  }
+}
+
+function decodeAuthToken(token) {
+  if (!token) {
+    return { type: 'guest' }
+  }
+
+  if (token.startsWith('testing-')) {
+    const payload = decodeTestingToken(token)
+    if (!payload) {
+      return { type: 'guest' }
+    }
+    return { type: 'testing', payload }
+  }
+
+  try {
+    const decoded = jwt.verify(token, JWT_SECRET)
+    console.log('✅ JWT authenticated user for transactions (frontend copy):', decoded.userId || decoded.id)
+    return { type: 'jwt', user: decoded }
+  } catch (jwtError) {
+    console.log('⚠️ JWT verification failed for transactions (frontend copy), checking Privy token:', jwtError.message)
+
+    try {
+      const base64Payload = token.split('.')[1]
+      if (!base64Payload) {
+        throw new Error('Invalid Privy token format')
+      }
+
+      const decoded = JSON.parse(Buffer.from(base64Payload, 'base64').toString('utf-8'))
+      console.log('🔍 Privy token payload (frontend transactions):', {
+        userId: decoded.sub,
+        email: decoded.email,
+        walletAddress: decoded.wallet?.address,
+      })
+
+      const authenticatedUser = {
+        id: decoded.sub,
+        privy_id: decoded.sub,
+        email: decoded.email,
+        jwt_wallet_address: decoded.wallet?.address,
+        isPrivyAuth: true,
+      }
+
+      console.log('✅ Privy token authenticated for transactions (frontend copy):', authenticatedUser.id)
+      return { type: 'privy', user: authenticatedUser }
+    } catch (privyError) {
+      console.log('⚠️ Privy token parsing also failed for transactions (frontend copy):', privyError.message)
+      return { type: 'guest' }
+    }
+  }
+}
+
+function findWalletAddress(user, authenticatedUser) {
+  const walletSources = [
+    authenticatedUser?.jwt_wallet_address,
+    user?.wallet_address,
+    user?.embedded_wallet_address,
+    user?.privy_wallet_address,
+  ]
+
+  const walletAddress = walletSources.find((addr) => addr && addr !== 'Not connected')
+  console.log(`🔍 Wallet address resolution (frontend transactions): ${walletAddress || 'No wallet found'}`)
+  return walletAddress
+}
+
+function buildTestingTransactions(payload) {
+  const walletAddress = payload.wallet_address || 'F7zDew151bya8KatZiHF6EXDBi8DVNJvrLE619vwypvG'
+  const now = Date.now()
+
+  return [
+    {
+      signature: 'TEST-HELIUS-IN-1',
+      description: 'Test SOL deposit',
+      timestamp: new Date(now - 60_000).toISOString(),
+      sol_amount: 0.25,
+      usd_amount: 40.0,
+      direction: 'incoming',
+      status: 'confirmed',
+      source: 'testing',
+    },
+    {
+      signature: 'TEST-HELIUS-OUT-1',
+      description: 'Test SOL withdrawal',
+      timestamp: new Date(now - 120_000).toISOString(),
+      sol_amount: 0.1,
+      usd_amount: 16.0,
+      direction: 'outgoing',
+      status: 'confirmed',
+      source: 'testing',
+    },
+  ].map((tx, index) => ({
+    ...tx,
+    index,
+    wallet_address: walletAddress,
+  }))
+}
+
+function lamportsToSol(lamports) {
+  return parseFloat(((lamports || 0) / 1e9).toFixed(6))
+}
+
+function normaliseHeliusTransactions(rawTransactions, walletAddress) {
+  if (!Array.isArray(rawTransactions)) {
+    return []
+  }
+
+  const lowerWallet = walletAddress.toLowerCase()
+
+  return rawTransactions.map((tx, index) => {
+    const nativeTransfers = Array.isArray(tx.nativeTransfers) ? tx.nativeTransfers : []
+
+    const netLamports = nativeTransfers.reduce((total, transfer) => {
+      const amount = Number(transfer.amount || 0)
+      if (!amount) {
+        return total
+      }
+
+      const toAddress = (transfer.toUserAccount || transfer.to || '').toLowerCase()
+      const fromAddress = (transfer.fromUserAccount || transfer.from || '').toLowerCase()
+
+      if (toAddress === lowerWallet) {
+        return total + amount
+      }
+      if (fromAddress === lowerWallet) {
+        return total - amount
+      }
+
+      return total
+    }, 0)
+
+    const solAmount = lamportsToSol(Math.abs(netLamports))
+    const direction = netLamports >= 0 ? 'incoming' : 'outgoing'
+    const usdAmount = parseFloat((solAmount * 160).toFixed(2))
+    const timestamp = tx.timestamp ? new Date(tx.timestamp * 1000).toISOString() : new Date().toISOString()
+
+    return {
+      signature: tx.signature,
+      description: tx.description || tx.type || 'Solana transaction',
+      timestamp,
+      sol_amount: solAmount,
+      usd_amount: usdAmount,
+      direction,
+      status: tx.status || 'confirmed',
+      source: 'helius',
+      nativeTransfers,
+      index,
+    }
+  })
+}
+
+async function fetchHeliusTransactions(walletAddress) {
+  if (!HELIUS_API_KEY || !walletAddress) {
+    console.log('⚠️ Missing Helius API key or wallet address for transactions (frontend copy)')
+    return []
+  }
+
+  try {
+    const heliusUrl = `${HELIUS_REST_BASE}/addresses/${walletAddress}/transactions?api-key=${HELIUS_API_KEY}&limit=20`
+    console.log('🌐 Fetching Helius transactions (frontend copy) from:', heliusUrl)
+
+    const response = await fetch(heliusUrl, { method: 'GET' })
+    if (!response.ok) {
+      console.warn('⚠️ Helius transactions response not OK (frontend copy):', response.status, response.statusText)
+      return []
+    }
+
+    const data = await response.json()
+    const normalised = normaliseHeliusTransactions(data, walletAddress)
+    console.log(`✅ Retrieved ${normalised.length} Helius transactions for wallet ${walletAddress} (frontend copy)`)
+    return normalised
+  } catch (error) {
+    console.error('❌ Error fetching transactions from Helius (frontend copy):', error)
+    return []
+  }
+}
 
 export async function GET(request) {
   const corsHeaders = {
@@ -8,44 +226,96 @@ export async function GET(request) {
   }
 
   try {
-    console.log('🎯 WALLET TRANSACTIONS ENDPOINT REACHED!')
-    
-    // Get Authorization header
     const authHeader = request.headers.get('authorization')
-    let token = null
-    
-    if (authHeader && authHeader.startsWith('Bearer ')) {
-      token = authHeader.substring(7)
+    const token = authHeader && authHeader.startsWith('Bearer ')
+      ? authHeader.substring(7)
+      : null
+
+    console.log('🔍 Wallet transactions request (frontend copy) - Token present:', !!token)
+
+    const authInfo = decodeAuthToken(token)
+
+    if (authInfo.type === 'testing') {
+      const transactions = buildTestingTransactions(authInfo.payload)
+      const responsePayload = {
+        transactions,
+        total_count: transactions.length,
+        wallet_address: transactions[0]?.wallet_address || authInfo.payload.wallet_address,
+        helius_enabled: true,
+        privy_authenticated: false,
+        timestamp: new Date().toISOString(),
+        source: 'testing',
+      }
+
+      console.log('🧪 Returning testing transactions response (frontend copy):', responsePayload)
+      return NextResponse.json(responsePayload, { headers: corsHeaders })
     }
-    
-    console.log('🔍 Wallet transactions request - Token present:', !!token)
-    
-    // For now, return empty transactions array since we're in testing phase
-    // In production, this would fetch real blockchain transactions using Helius API
-    const transactionsResponse = {
-      transactions: [],
-      total_count: 0,
-      wallet_address: 'F7zDew151bya8KatZiHF6EXDBi8DVNJvrLE619vwypvG', // Default for testing
-      timestamp: new Date().toISOString()
+
+    if (authInfo.type === 'guest') {
+      console.log('🎭 Guest request for transactions (frontend copy) - returning empty list')
+      return NextResponse.json({
+        transactions: [],
+        total_count: 0,
+        wallet_address: 'Not connected',
+        helius_enabled: !!HELIUS_API_KEY,
+        privy_authenticated: false,
+        timestamp: new Date().toISOString(),
+      }, { headers: corsHeaders })
     }
-    
-    console.log('📊 Returning transactions data:', transactionsResponse)
-    return NextResponse.json(transactionsResponse, { headers: corsHeaders })
-    
+
+    const authenticatedUser = authInfo.user
+    const db = await getDb()
+    const users = db.collection('users')
+
+    const user = await users.findOne({
+      $or: [
+        { id: authenticatedUser.id },
+        { privy_id: authenticatedUser.privy_id || authenticatedUser.id },
+      ],
+    })
+
+    const walletAddress = findWalletAddress(user, authenticatedUser)
+
+    if (!walletAddress) {
+      console.log('⚠️ No wallet address found for authenticated user (frontend copy) - returning empty transactions')
+      return NextResponse.json({
+        transactions: [],
+        total_count: 0,
+        wallet_address: 'Not connected',
+        helius_enabled: !!HELIUS_API_KEY,
+        privy_authenticated: Boolean(authenticatedUser?.isPrivyAuth),
+        timestamp: new Date().toISOString(),
+      }, { headers: corsHeaders })
+    }
+
+    const transactions = await fetchHeliusTransactions(walletAddress)
+
+    const responsePayload = {
+      transactions,
+      total_count: transactions.length,
+      wallet_address: walletAddress,
+      helius_enabled: !!HELIUS_API_KEY,
+      privy_authenticated: Boolean(authenticatedUser?.isPrivyAuth),
+      timestamp: new Date().toISOString(),
+      source: transactions.length ? 'helius' : 'helius-empty',
+    }
+
+    console.log('📊 Returning transactions data (frontend copy):', responsePayload)
+    return NextResponse.json(responsePayload, { headers: corsHeaders })
   } catch (error) {
-    console.error('❌ Error in wallet transactions endpoint:', error)
-    return NextResponse.json({ 
+    console.error('❌ Error in wallet transactions endpoint (frontend copy):', error)
+    return NextResponse.json({
       error: 'Internal Server Error',
       transactions: [],
-      total_count: 0
-    }, { 
-      status: 500, 
-      headers: corsHeaders 
+      total_count: 0,
+    }, {
+      status: 500,
+      headers: corsHeaders,
     })
   }
 }
 
-export async function OPTIONS(request) {
+export async function OPTIONS() {
   return new NextResponse(null, {
     status: 200,
     headers: {


### PR DESCRIPTION
## Summary
- reinstate Helius-powered Solana transaction fetching in the wallet transactions API with Privy token decoding
- normalize Helius responses and provide testing fallbacks when running against mock tokens or missing wallets
- mirror the updated Helius integration in the frontend copy of the wallet transactions endpoint

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5cc3517c88330881eb1ab9bed56ce