### PR TITLE
Add configurable private Solana RPC support

### DIFF
--- a/DEPLOYMENT_INSTRUCTIONS.md
+++ b/DEPLOYMENT_INSTRUCTIONS.md
@@ -36,7 +36,10 @@ This project has been restructured for independent deployment:
    NEXT_PUBLIC_COLYSEUS_ENDPOINT=wss://<your-colyseus-app-id>.colyseus.cloud
    NEXT_PUBLIC_PRIVY_APP_ID=cmdycgltk007ljs0bpjbjqx0a
    NEXT_PUBLIC_SOLANA_RPC=https://api.mainnet-beta.solana.com
-   NEXT_PUBLIC_HELIUS_RPC=https://mainnet.helius-rpc.com/?api-key=gameloop-migrate
+   # Optional private RPC (e.g. Helius) that will be tried before public endpoints
+   NEXT_PUBLIC_SOLANA_PRIVATE_RPC=https://mainnet.helius-rpc.com/?api-key=your-helius-key
+   # Optional comma separated list of extra priority RPC URLs
+   NEXT_PUBLIC_SOLANA_RPC_PRIORITY_LIST=https://rpc.backup1.com,https://rpc.backup2.com
    ```
 
 ### Files Structure

--- a/app/page.js
+++ b/app/page.js
@@ -44,6 +44,11 @@ export default function TurfLootTactical() {
     () =>
       buildSolanaRpcEndpointList({
         network: process.env.NEXT_PUBLIC_SOLANA_NETWORK || 'mainnet-beta',
+        privateRpc:
+          process.env.NEXT_PUBLIC_SOLANA_PRIVATE_RPC ||
+          process.env.NEXT_PUBLIC_SOLANA_HELIUS_RPC ||
+          process.env.NEXT_PUBLIC_SOLANA_RPC_PRIVATE ||
+          process.env.NEXT_PUBLIC_SOLANA_RPC_HELIUS,
         primary: process.env.NEXT_PUBLIC_SOLANA_RPC,
         list: process.env.NEXT_PUBLIC_SOLANA_RPC_LIST,
         fallbacks: process.env.NEXT_PUBLIC_SOLANA_RPC_FALLBACKS
@@ -405,47 +410,52 @@ export default function TurfLootTactical() {
     
     console.log('🔍 Checking Solana balance for:', walletAddress)
     
-    // OPTION 1: Try Helius RPC provider first (now with working API key)
-    const heliusRpc = process.env.NEXT_PUBLIC_HELIUS_RPC
-    
-    if (heliusRpc) {
-      try {
-        console.log('🚀 Using Helius RPC for real-time balance')
-        
-        const response = await fetch(heliusRpc, {
-          method: 'POST',
-          headers: { 
-            'Content-Type': 'application/json',
-            'Accept': 'application/json'
-          },
-          body: JSON.stringify({
-            jsonrpc: '2.0',
-            id: 1,
-            method: 'getBalance', 
-            params: [walletAddress]
-          }),
-          signal: AbortSignal.timeout(5000)
-        })
-        
-        if (response.ok) {
-          const data = await response.json()
-          if (data.result?.value !== undefined) {
-            const solBalance = data.result.value / 1000000000
-            console.log(`✅ Real balance from Helius:`, solBalance, 'SOL')
-            
-            // DEPOSIT DETECTION: Check for balance increases
-            await detectDepositAndProcessFee(solBalance, walletAddress)
-            
-            return solBalance
+    // OPTION 1: Try private RPC provider first (Helius, Triton, etc.)
+    const privateRpcEndpoint =
+      process.env.NEXT_PUBLIC_SOLANA_PRIVATE_RPC ||
+      process.env.NEXT_PUBLIC_SOLANA_HELIUS_RPC ||
+      process.env.NEXT_PUBLIC_SOLANA_RPC_PRIVATE ||
+      process.env.NEXT_PUBLIC_SOLANA_RPC_HELIUS ||
+      process.env.NEXT_PUBLIC_HELIUS_RPC
+
+        if (privateRpcEndpoint) {
+          try {
+            console.log('🚀 Using private Solana RPC for real-time balance')
+
+            const response = await fetch(privateRpcEndpoint, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json'
+              },
+              body: JSON.stringify({
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'getBalance',
+                params: [walletAddress]
+              }),
+              signal: AbortSignal.timeout(5000)
+            })
+
+            if (response.ok) {
+              const data = await response.json()
+              if (data.result?.value !== undefined) {
+                const solBalance = data.result.value / 1000000000
+                console.log(`✅ Real balance from private RPC:`, solBalance, 'SOL')
+
+                // DEPOSIT DETECTION: Check for balance increases
+                await detectDepositAndProcessFee(solBalance, walletAddress)
+
+                return solBalance
+              }
+            } else {
+              console.log('❌ Private RPC failed:', response.status)
+            }
+          } catch (error) {
+            console.log('❌ Private RPC error:', error.message)
           }
-        } else {
-          console.log('❌ Helius RPC failed:', response.status)
         }
-      } catch (error) {
-        console.log('❌ Helius RPC error:', error.message)
-      }
-    }
-    
+
     // OPTION 2: Fallback to other RPC providers
     const fallbackEndpoints = [
       'https://api.mainnet-beta.solana.com',

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -14,12 +14,22 @@ This frontend connects to the Colyseus Cloud game server for multiplayer gamepla
 ```
 NEXT_PUBLIC_COLYSEUS_ENDPOINT=wss://au-syd-ab3eaf4e.colyseus.cloud
 NEXT_PUBLIC_PRIVY_APP_ID=cmdycgltk007ljs0bpjbjqx0a
+
+# Primary RPC used by the client (falls back to cluster defaults when not set)
 NEXT_PUBLIC_SOLANA_RPC=https://api.mainnet-beta.solana.com
-NEXT_PUBLIC_HELIUS_RPC=https://mainnet.helius-rpc.com/?api-key=gameloop-migrate
+
+# Optional private RPC (Helius, Triton, etc.) that is tried before public endpoints
+NEXT_PUBLIC_SOLANA_PRIVATE_RPC=https://mainnet.helius-rpc.com/?api-key=your-helius-key
+
+# Optional comma-separated list of additional priority RPCs
+NEXT_PUBLIC_SOLANA_RPC_PRIORITY_LIST=https://another-rpc.example.com,https://backup-rpc.example.com
+
 NEXT_PUBLIC_SOLANA_NETWORK=devnet
 NEXT_PUBLIC_GAME_MODE=multiplayer
 NEXT_PUBLIC_MAX_PLAYERS=6
 ```
+
+Private RPC URLs are automatically sanitised (query strings removed) in application logs so that API keys are never written to the console.
 
 ### Features
 - **Privy Authentication** - Wallet connection and user management

--- a/lib/paid/feeManager.js
+++ b/lib/paid/feeManager.js
@@ -146,17 +146,74 @@ const normaliseList = (value) =>
     .map((entry) => entry.trim())
     .filter(Boolean)
 
+const sanitiseRpcEndpoint = (endpoint) => {
+  if (!endpoint || typeof endpoint !== 'string') {
+    return endpoint
+  }
+
+  try {
+    const url = new URL(endpoint)
+    url.search = ''
+
+    if (url.username) {
+      url.username = '***'
+    }
+
+    if (url.password) {
+      url.password = '***'
+    }
+
+    return url.toString()
+  } catch (error) {
+    return endpoint
+      .replace(/(api[-_]?key|auth|token|secret|pass(word)?)=([^&]+)/gi, '$1=***')
+      .split('?')[0]
+  }
+}
+
+const appendEndpoint = (target, value) => {
+  if (typeof value !== 'string') {
+    return
+  }
+
+  const trimmed = value.trim()
+  if (trimmed) {
+    target.push(trimmed)
+  }
+}
+
 export const buildSolanaRpcEndpointList = ({
   network = 'mainnet-beta',
   primary,
+  privateRpc,
   list = '',
   fallbacks = ''
 } = {}) => {
   const endpoints = []
 
-  if (primary) {
-    endpoints.push(primary.trim())
-  }
+  appendEndpoint(endpoints, privateRpc)
+
+  const envPriorityCandidates = [
+    process.env.NEXT_PUBLIC_SOLANA_PRIVATE_RPC,
+    process.env.NEXT_PUBLIC_SOLANA_HELIUS_RPC,
+    process.env.NEXT_PUBLIC_SOLANA_RPC_PRIVATE,
+    process.env.NEXT_PUBLIC_SOLANA_RPC_HELIUS
+  ]
+
+  envPriorityCandidates.forEach((candidate) => appendEndpoint(endpoints, candidate))
+
+  appendEndpoint(endpoints, primary)
+
+  const envPriorityLists = [
+    process.env.NEXT_PUBLIC_SOLANA_RPC_PRIORITY_LIST,
+    process.env.NEXT_PUBLIC_SOLANA_PRIVATE_RPC_LIST,
+    process.env.NEXT_PUBLIC_SOLANA_HELIUS_RPC_LIST
+  ]
+
+  envPriorityLists
+    .map((value) => normaliseList(value))
+    .forEach((entries) => endpoints.push(...entries))
+
   endpoints.push(...normaliseList(list))
   endpoints.push(...normaliseList(fallbacks))
 
@@ -168,13 +225,13 @@ export const buildSolanaRpcEndpointList = ({
 
   const defaultFallbacks = network === 'mainnet-beta'
     ? [
-        'https://api.mainnet-beta.solana.com',
+        process.env.NEXT_PUBLIC_SOLANA_RPC || 'https://api.mainnet-beta.solana.com',
         'https://solana-api.projectserum.com',
         'https://rpc.publicnode.com/solana',
         'https://1rpc.io/solana'
       ]
     : [
-        'https://api.devnet.solana.com',
+        process.env.NEXT_PUBLIC_SOLANA_RPC || 'https://api.devnet.solana.com',
         'https://rpc.publicnode.com/solana-devnet'
       ]
 
@@ -319,8 +376,9 @@ const connectToSolana = async (rpcEndpoints = []) => {
       const latestBlockhash = await connection.getLatestBlockhash()
       return { connection, latestBlockhash, endpoint }
     } catch (error) {
-      console.error(`⚠️ RPC endpoint failed (${endpoint}):`, error)
-      errors.push(`${endpoint}: ${error?.message || error}`)
+      const sanitised = sanitiseRpcEndpoint(endpoint)
+      console.error(`⚠️ RPC endpoint failed (${sanitised}):`, error)
+      errors.push(`${sanitised}: ${error?.message || error}`)
     }
   }
 
@@ -494,7 +552,8 @@ export const deductPaidRoomFee = async ({
   }
 
   const { connection, latestBlockhash, endpoint } = await connectToSolana(rpcEndpoints)
-  log.log?.('🌐 Using Solana RPC endpoint:', endpoint)
+  const sanitisedEndpoint = sanitiseRpcEndpoint(endpoint)
+  log.log?.('🌐 Using Solana RPC endpoint:', sanitisedEndpoint)
 
   const fromPublicKey = new PublicKey(walletAddress)
   const prizeVaultPublicKey = new PublicKey(prizeVault)
@@ -558,7 +617,8 @@ export const deductPaidRoomFee = async ({
     prizeVault,
     feeVault,
     chain: chainIdentifier,
-    memoAttached: Boolean(memoPayload)
+    memoAttached: Boolean(memoPayload),
+    rpcEndpoint: sanitisedEndpoint
   }
 
   log.log?.('🔄 Sending Solana transaction via Privy...', logContext)
@@ -596,7 +656,7 @@ export const deductPaidRoomFee = async ({
     log.log?.('✅ Solana transaction confirmed via Privy', {
       ...logContext,
       signature,
-      rpcEndpoint: endpoint,
+      rpcEndpoint: sanitisedEndpoint,
       signingMode
     })
   } catch (error) {
@@ -611,7 +671,7 @@ export const deductPaidRoomFee = async ({
     feeLamports,
     totalCostSol,
     costs: effectiveCosts,
-    rpcEndpoint: endpoint,
+    rpcEndpoint: sanitisedEndpoint,
     walletAddress,
     prizeVault,
     feeVault,


### PR DESCRIPTION
## Summary
- prioritise configurable private Solana RPC endpoints (Helius, etc.) and sanitise RPC logging in the paid room fee manager
- update the TurfLoot page logic to use the new private RPC configuration when fetching balances and paying room fees
- document the new environment variables for supplying private or priority Solana RPC URLs

## Testing
- npm run lint *(fails: existing lint violations in unrelated legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68e5d3ca8fc48330b47a06cb184bcd31