### PR TITLE
Fix arena join to use server-provided Colyseus endpoints

### DIFF
--- a/app/agario/page.js
+++ b/app/agario/page.js
@@ -288,6 +288,11 @@ const AgarIOGame = () => {
     const maxPlayers = parseInt(urlParams.get('maxPlayers')) || 50
     const gameName = urlParams.get('name') || 'TurfLoot Arena'
     const regionId = urlParams.get('regionId') || 'au-syd'
+    const endpointFromQuery = urlParams.get('endpoint')
+    const fallbackEndpoint = process.env.NEXT_PUBLIC_COLYSEUS_ENDPOINT || 'wss://au-syd-ab3eaf4e.colyseus.cloud'
+    const resolvedEndpoint = endpointFromQuery && endpointFromQuery.trim() !== ''
+      ? endpointFromQuery
+      : fallbackEndpoint
     
     console.log('📊 Authoritative game configuration:', {
       roomId,
@@ -297,7 +302,8 @@ const AgarIOGame = () => {
       maxPlayers,
       gameName,
       isAuthoritative: true,
-      serverSide: 'Colyseus Cloud'
+      serverSide: 'Colyseus Cloud',
+      endpoint: resolvedEndpoint
     })
     
     // 🔥 CRITICAL: Connect to Colyseus arena room
@@ -327,9 +333,11 @@ const AgarIOGame = () => {
         walletAddress: urlWalletAddress
       })
       
-      const room = await joinArena({ 
+      const room = await joinArena({
         privyUserId: realPrivyUserId,
-        playerName: realPlayerName
+        playerName: realPlayerName,
+        specificRoomId: roomId,
+        endpoint: resolvedEndpoint
       })
       
       console.log('🎮 Connected with player name:', realPlayerName, 'and ID:', realPrivyUserId)
@@ -385,7 +393,7 @@ const AgarIOGame = () => {
       return {
         success: true,
         roomId: room.id,
-        serverEndpoint: process.env.NEXT_PUBLIC_COLYSEUS_ENDPOINT,
+        serverEndpoint: resolvedEndpoint,
         gameMode: fee > 0 ? 'cash-game' : 'practice',
         region: region,
         maxPlayers: maxPlayers

--- a/app/arena/page.js
+++ b/app/arena/page.js
@@ -1320,6 +1320,10 @@ const MultiplayerArena = () => {
     const componentId = componentIdRef.current
     console.log(`🔗 [${componentId}] Connection attempt started for user:`, privyUserId)
 
+    const queryEndpoint = searchParams?.get('endpoint')
+    const fallbackEndpoint = process.env.NEXT_PUBLIC_COLYSEUS_ENDPOINT || 'wss://au-syd-ab3eaf4e.colyseus.cloud'
+    const endpoint = queryEndpoint && queryEndpoint.trim() !== '' ? queryEndpoint : fallbackEndpoint
+
     clearPingInterval()
     resetPingState(true)
 
@@ -1384,11 +1388,11 @@ const MultiplayerArena = () => {
       console.log('🚀 Creating dedicated Colyseus client for this arena...')
       setConnectionStatus('connecting')
       
-      // Get the endpoint from environment or fallback
-      const endpoint = process.env.NEXT_PUBLIC_COLYSEUS_ENDPOINT || 'wss://au-syd-ab3eaf4e.colyseus.cloud'
+      // Use the resolved endpoint from query parameters when available
       console.log('🎯 Colyseus endpoint:', endpoint)
       console.log('🎯 Environment check:', {
-        endpoint: process.env.NEXT_PUBLIC_COLYSEUS_ENDPOINT,
+        fallbackEndpoint: process.env.NEXT_PUBLIC_COLYSEUS_ENDPOINT,
+        endpointFromQuery: queryEndpoint,
         playerName,
         privyUserId,
         roomId
@@ -1619,7 +1623,8 @@ const MultiplayerArena = () => {
       console.error(`❌ [${componentId}] Error details:`, {
         message: error.message,
         stack: error.stack,
-        endpoint: process.env.NEXT_PUBLIC_COLYSEUS_ENDPOINT
+        endpoint,
+        endpointFromQuery: queryEndpoint
       })
       setConnectionStatus('failed')
       

--- a/app/page.js
+++ b/app/page.js
@@ -2122,9 +2122,13 @@ export default function TurfLootTactical() {
     console.log('📊 Server details:', serverData)
     
     try {
-      // Colyseus server configuration
+      // Colyseus server configuration – always prefer the endpoint provided by the
+      // server browser payload so we join the exact deployment the user selected.
+      const fallbackEndpoint = process.env.NEXT_PUBLIC_COLYSEUS_ENDPOINT || 'ws://localhost:2567'
+      const resolvedEndpoint = serverData.endpoint || fallbackEndpoint
+
       const colyseusServerInfo = {
-        endpoint: process.env.NEXT_PUBLIC_COLYSEUS_ENDPOINT || 'ws://localhost:2567',
+        endpoint: resolvedEndpoint,
         roomType: 'arena',
         region: serverData.region || 'global'
       }
@@ -2292,6 +2296,10 @@ export default function TurfLootTactical() {
         privyUserId: privyUserData.privyUserId,
         playerName: encodeURIComponent(privyUserData.playerName),
         walletAddress: privyUserData.walletAddress || ''
+      }
+
+      if (serverData.endpoint) {
+        queryParams.endpoint = serverData.endpoint
       }
 
       if (appliedFeePercentage !== null && feeResult) {

--- a/lib/colyseus.js
+++ b/lib/colyseus.js
@@ -11,12 +11,22 @@ class TurfLootColyseusClient {
     console.log(`🔗 Endpoint: ${this.endpoint}`)
   }
 
-  async joinArena({ privyUserId, playerName = null, specificRoomId = null, stakeAmount = 0, isAuthenticated = false }) {
+  async joinArena({ privyUserId, playerName = null, specificRoomId = null, stakeAmount = 0, isAuthenticated = false, endpoint = null }) {
     try {
       console.log('🚀 Connecting to Colyseus server...')
       console.log('👤 Player info:', { privyUserId, playerName })
-      
-      // Create Colyseus client 
+
+      const targetEndpoint = endpoint || this.endpoint
+      if (!targetEndpoint) {
+        throw new Error('No Colyseus endpoint configured')
+      }
+
+      if (this.endpoint !== targetEndpoint) {
+        console.log('🔁 Updating Colyseus endpoint:', targetEndpoint)
+        this.endpoint = targetEndpoint
+      }
+
+      // Create Colyseus client
       this.client = new Client(this.endpoint)
       
       // Use joinOrCreate with required fields that the server expects
@@ -26,13 +36,19 @@ class TurfLootColyseusClient {
         ? parseFloat(stakeAmount)
         : stakeAmount
 
-      this.room = await this.client.joinOrCreate("arena", {
+      const joinOptions = {
         // Include required fields that server expects to prevent 4002 errors
         playerName: playerName || 'Anonymous Player',
         privyUserId: privyUserId || 'anonymous-' + Date.now(),
         stakeAmount: Number.isFinite(normalizedStake) ? normalizedStake : 0,
         isAuthenticated
-      })
+      }
+
+      if (specificRoomId) {
+        joinOptions.roomName = specificRoomId
+      }
+
+      this.room = await this.client.joinOrCreate("arena", joinOptions)
       
       this.isConnected = true
       


### PR DESCRIPTION
## Summary
- pass the server browser endpoint through join navigation so arena joins target the selected Colyseus deployment
- update the arena and agario pages plus the shared Colyseus client to honor query-provided endpoints when connecting

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e5d6239b4c8330803734cc2cd40af6