### PR TITLE
Handle Solana network fee buffer for paid room joins

### DIFF
--- a/lib/paid/feeManager.js
+++ b/lib/paid/feeManager.js
@@ -15,6 +15,7 @@ const MEMO_PROGRAM_ID = 'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr'
 
 const DEFAULT_USD_PER_SOL = 150
 const DEFAULT_FEE_PERCENTAGE = 10
+const DEFAULT_NETWORK_FEE_LAMPORTS_BUFFER = 5000
 
 const normaliseCurrency = (value) => {
   if (!value) {
@@ -515,7 +516,7 @@ export const deductPaidRoomFee = async ({
   if (currency === 'SOL' || currency === 'LAMPORTS') {
     if (currentSolBalance < requiredSolBalance) {
       throw new Error(
-        `Insufficient SOL balance. Need ${requiredSolBalance.toFixed(6)} SOL, have ${currentSolBalance.toFixed(6)} SOL`
+        `Insufficient SOL balance. Need ${requiredSolBalance.toFixed(6)} SOL for room entry (network fees extra), have ${currentSolBalance.toFixed(6)} SOL`
       )
     }
   } else if (currentUsdBalance < requiredUsdBalance) {
@@ -604,6 +605,27 @@ export const deductPaidRoomFee = async ({
     return tx
   }
 
+  const transaction = buildTransaction()
+
+  let estimatedNetworkFeeLamports = DEFAULT_NETWORK_FEE_LAMPORTS_BUFFER
+  try {
+    const feeResult = await connection.getFeeForMessage(transaction.compileMessage(), 'confirmed')
+    if (feeResult && typeof feeResult.value === 'number' && feeResult.value > 0) {
+      estimatedNetworkFeeLamports = Math.max(feeResult.value, DEFAULT_NETWORK_FEE_LAMPORTS_BUFFER)
+    }
+  } catch (error) {
+    log.warn?.('⚠️ Unable to estimate network fee from RPC response, using default buffer.', error)
+  }
+
+  const estimatedNetworkFeeSol = estimatedNetworkFeeLamports / LAMPORTS_PER_SOL
+
+  if (currentSolBalance < totalCostSol + estimatedNetworkFeeSol) {
+    const deficit = totalCostSol + estimatedNetworkFeeSol - currentSolBalance
+    throw new Error(
+      `Insufficient SOL balance. Need ${(totalCostSol + estimatedNetworkFeeSol).toFixed(6)} SOL including network fees, have ${currentSolBalance.toFixed(6)} SOL. Top up at least ${deficit.toFixed(6)} SOL.`
+    )
+  }
+
   const chainIdentifier = deriveSolanaChainIdentifier(solanaChain)
   const preflightOptions = { preflightCommitment: 'confirmed' }
 
@@ -618,7 +640,9 @@ export const deductPaidRoomFee = async ({
     feeVault,
     chain: chainIdentifier,
     memoAttached: Boolean(memoPayload),
-    rpcEndpoint: sanitisedEndpoint
+    rpcEndpoint: sanitisedEndpoint,
+    estimatedNetworkFeeLamports,
+    estimatedNetworkFeeSol
   }
 
   log.log?.('🔄 Sending Solana transaction via Privy...', logContext)
@@ -628,7 +652,6 @@ export const deductPaidRoomFee = async ({
   let signingMode = null
 
   try {
-    const transaction = buildTransaction()
     const sendResult = await sendTransactionWithPrivy({
       transaction,
       chain: chainIdentifier,
@@ -677,7 +700,9 @@ export const deductPaidRoomFee = async ({
     feeVault,
     memo: memo ?? memoPayload,
     rawTransaction: rawTransactionBytes,
-    signingMode
+    signingMode,
+    networkFeeLamports: estimatedNetworkFeeLamports,
+    networkFeeSol: estimatedNetworkFeeSol
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure the paid room join flow checks for extra SOL to cover network fees and updates wallet balances with the deducted fee
- estimate Solana transaction fees before invoking Privy, aborting with a clear error if the wallet cannot cover them and returning the fee details on success

## Testing
- npm run lint *(fails: existing lint errors in legacy frontend files)*

------
https://chatgpt.com/codex/tasks/task_e_68e5f437abf8833088a9bcda11da7f7e