### PR TITLE
Improve Privy Solana wallet detection

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -83,6 +83,12 @@ const getWalletAddress = (wallet) => {
   return undefined
 }
 
+const isSolanaChain = (chainType) =>
+  typeof chainType === 'string' && chainType.toLowerCase().startsWith('solana')
+
+const isSolanaAddress = (address) =>
+  typeof address === 'string' && !address.toLowerCase().startsWith('0x') && address.length >= 32
+
 export default function TurfLootTactical() {
   const router = useRouter()
 
@@ -110,7 +116,10 @@ export default function TurfLootTactical() {
     return Array.from(deduped.values())
   }, [privyWallets, externalWallets])
   const solanaWallets = useMemo(
-    () => wallets.filter(wallet => wallet?.chainType === 'solana'),
+    () =>
+      wallets.filter(wallet =>
+        isSolanaChain(wallet?.chainType) && isSolanaAddress(getWalletAddress(wallet))
+      ),
     [wallets]
   )
   const walletAddressesSignature = useMemo(() => {
@@ -668,7 +677,9 @@ export default function TurfLootTactical() {
     console.log('🧪 Privy user object:', JSON.stringify(privyUser, null, 2))
 
     if (wallets?.length > 0) {
-      const solanaWallet = wallets.find(wallet => wallet.chainType === 'solana')
+      const solanaWallet = wallets.find(wallet =>
+        isSolanaChain(wallet.chainType) && isSolanaAddress(getWalletAddress(wallet))
+      )
 
       if (solanaWallet) {
         const address = getWalletAddress(solanaWallet)
@@ -719,8 +730,10 @@ export default function TurfLootTactical() {
       
       // Check if wallet exists in linked accounts
       if (privyUser?.linkedAccounts) {
-        const solanaAccounts = privyUser.linkedAccounts.filter(acc => 
-          acc.type === 'wallet' && (acc.chainType === 'solana' || acc.address === 'F7zDew151bya8KatZiHF6EXDBi8DVNJvrLE619vwypvG')
+        const solanaAccounts = privyUser.linkedAccounts.filter(acc =>
+          acc.type === 'wallet' &&
+          (isSolanaChain(acc.chainType) || acc.address === 'F7zDew151bya8KatZiHF6EXDBi8DVNJvrLE619vwypvG') &&
+          isSolanaAddress(acc.address)
         )
         console.log('🔍 Solana accounts found in linkedAccounts:', solanaAccounts)
       }
@@ -2849,7 +2862,7 @@ export default function TurfLootTactical() {
           connectorType: w.connectorType 
         })))
         
-        solanaWallet = wallets.find(w => w.chainType === 'solana')
+        solanaWallet = wallets.find(w => isSolanaChain(w.chainType) && isSolanaAddress(getWalletAddress(w)))
         if (solanaWallet) {
           walletSource = 'useWallets'
         }
@@ -2865,7 +2878,7 @@ export default function TurfLootTactical() {
         
         // Check if embedded wallet is the Solana wallet we're looking for
         if (privyUser.wallet.address === 'F7zDew151bya8KatZiHF6EXDBi8DVNJvrLE619vwypvG' ||
-            privyUser.wallet.chainType === 'solana') {
+            isSolanaChain(privyUser.wallet.chainType)) {
           solanaWallet = {
             address: privyUser.wallet.address,
             chainType: 'solana',
@@ -2883,9 +2896,10 @@ export default function TurfLootTactical() {
           chainType: acc.chainType
         })))
         
-        const linkedSolanaWallet = privyUser.linkedAccounts.find(acc => 
-          acc.type === 'wallet' && 
-          (acc.chainType === 'solana' || acc.address === 'F7zDew151bya8KatZiHF6EXDBi8DVNJvrLE619vwypvG')
+        const linkedSolanaWallet = privyUser.linkedAccounts.find(acc =>
+          acc.type === 'wallet' &&
+          (isSolanaChain(acc.chainType) || acc.address === 'F7zDew151bya8KatZiHF6EXDBi8DVNJvrLE619vwypvG') &&
+          isSolanaAddress(acc.address)
         )
         
         if (linkedSolanaWallet) {

--- a/app/test-privy-solana/page.js
+++ b/app/test-privy-solana/page.js
@@ -3,10 +3,14 @@
 import React, { useMemo, useState } from 'react'
 import { usePrivy, useWallets } from '@privy-io/react-auth'
 
+function isSolanaChain(chainType) {
+  return typeof chainType === 'string' && chainType.toLowerCase().startsWith('solana')
+}
+
 function pickDefaultSolanaWallet(wallets) {
   return (
-    wallets.find(w => w.chainType === 'solana' && w.walletClientType === 'privy') ||
-    wallets.find(w => w.chainType === 'solana') ||
+    wallets.find(w => isSolanaChain(w.chainType) && w.walletClientType === 'privy') ||
+    wallets.find(w => isSolanaChain(w.chainType)) ||
     null
   )
 }
@@ -20,7 +24,7 @@ export default function TestPrivySolana() {
   const { wallets } = useWallets()
 
   const solWallets = useMemo(
-    () => wallets.filter(w => w.chainType === 'solana'),
+    () => wallets.filter(w => isSolanaChain(w.chainType)),
     [wallets]
   )
 

--- a/frontend/app/page.js
+++ b/frontend/app/page.js
@@ -71,20 +71,29 @@ export default function TurfLootTactical() {
     return 'solana:mainnet'
   }, [])
 
+  const isSolanaChain = (chainType) =>
+    typeof chainType === 'string' && chainType.toLowerCase().startsWith('solana')
+
+  const isSolanaAddress = (address) =>
+    typeof address === 'string' && !address.toLowerCase().startsWith('0x') && address.length >= 32
+
   const resolveSolanaWallet = () => {
     if (wallets && wallets.length > 0) {
-      const prioritized = wallets.filter(w => w?.chainType === 'solana')
+      const prioritized = wallets.filter(w => isSolanaChain(w?.chainType))
       if (prioritized.length > 0) {
         return prioritized[0]
       }
     }
 
-    if (privyUser?.wallet?.chainType === 'solana') {
+    if (isSolanaChain(privyUser?.wallet?.chainType) && isSolanaAddress(privyUser?.wallet?.address)) {
       return privyUser.wallet
     }
 
     const linkedSolana = privyUser?.linkedAccounts?.find(
-      account => account?.type === 'wallet' && account?.chainType === 'solana'
+      account =>
+        account?.type === 'wallet' &&
+        isSolanaChain(account?.chainType) &&
+        isSolanaAddress(account?.address)
     )
 
     if (linkedSolana) {
@@ -542,40 +551,40 @@ export default function TurfLootTactical() {
     // Method 1: Check useWallets hook
     if (wallets?.length > 0) {
       console.log('🔍 Checking useWallets hook:', wallets)
-      const solanaWallet = wallets.find(w => w.chainType === 'solana')
-      if (solanaWallet?.address) {
+      const solanaWallet = wallets.find(w => isSolanaChain(w.chainType) && isSolanaAddress(w.address))
+      if (solanaWallet?.address && isSolanaAddress(solanaWallet.address)) {
         console.log('✅ Found Solana wallet via useWallets:', solanaWallet.address)
         return solanaWallet.address
       }
     }
-    
+
     // Method 2: Check embedded wallet (remove hardcoded address)
-    if (privyUser.wallet?.address) {
+    if (isSolanaChain(privyUser.wallet?.chainType) && isSolanaAddress(privyUser.wallet?.address)) {
       console.log('✅ Found via embedded wallet:', privyUser.wallet.address)
       return privyUser.wallet.address
     }
-    
+
     // Method 3: Check linked accounts for any Solana wallet
     if (privyUser.linkedAccounts?.length > 0) {
       console.log('🔍 Checking linkedAccounts:', privyUser.linkedAccounts)
-      const solanaAccount = privyUser.linkedAccounts.find(acc => 
-        acc.type === 'wallet' && acc.chainType === 'solana'
+      const solanaAccount = privyUser.linkedAccounts.find(acc =>
+        acc.type === 'wallet' && isSolanaChain(acc.chainType) && isSolanaAddress(acc.address)
       )
       if (solanaAccount?.address) {
         console.log('✅ Found Solana wallet via linkedAccounts:', solanaAccount.address)
         return solanaAccount.address
       }
     }
-    
+
     // Method 4: Check for any wallet with valid Solana address format
     const allWallets = [
       ...(privyUser.linkedAccounts || []),
       ...(wallets || []),
       privyUser.wallet
     ].filter(Boolean)
-    
+
     for (const wallet of allWallets) {
-      if (wallet?.address && wallet.address.length >= 32) {
+      if (isSolanaAddress(wallet?.address)) {
         console.log('✅ Found potential Solana wallet:', wallet.address)
         return wallet.address
       }
@@ -680,8 +689,9 @@ export default function TurfLootTactical() {
       
       // Check if wallet exists in linked accounts
       if (privyUser?.linkedAccounts) {
-        const solanaAccounts = privyUser.linkedAccounts.filter(acc => 
-          acc.type === 'wallet' && (acc.chainType === 'solana' || acc.address === 'F7zDew151bya8KatZiHF6EXDBi8DVNJvrLE619vwypvG')
+        const solanaAccounts = privyUser.linkedAccounts.filter(acc =>
+          acc.type === 'wallet' &&
+          (isSolanaChain(acc.chainType) || acc.address === 'F7zDew151bya8KatZiHF6EXDBi8DVNJvrLE619vwypvG')
         )
         console.log('🔍 Solana accounts found in linkedAccounts:', solanaAccounts)
       }
@@ -2649,7 +2659,7 @@ export default function TurfLootTactical() {
           connectorType: w.connectorType 
         })))
         
-        solanaWallet = wallets.find(w => w.chainType === 'solana')
+        solanaWallet = wallets.find(w => isSolanaChain(w.chainType) && isSolanaAddress(w.address))
         if (solanaWallet) {
           walletSource = 'useWallets'
         }
@@ -2665,7 +2675,7 @@ export default function TurfLootTactical() {
 
         // Check if embedded wallet is the Solana wallet we're looking for
         if (privyUser.wallet.address === 'F7zDew151bya8KatZiHF6EXDBi8DVNJvrLE619vwypvG' ||
-            privyUser.wallet.chainType === 'solana') {
+            isSolanaChain(privyUser.wallet.chainType)) {
           solanaWallet = privyUser.wallet
           walletSource = 'privyUser.wallet'
         }
@@ -2681,7 +2691,8 @@ export default function TurfLootTactical() {
         
         const linkedSolanaWallet = privyUser.linkedAccounts.find(acc =>
           acc.type === 'wallet' &&
-          (acc.chainType === 'solana' || acc.address === 'F7zDew151bya8KatZiHF6EXDBi8DVNJvrLE619vwypvG')
+          (isSolanaChain(acc.chainType) || acc.address === 'F7zDew151bya8KatZiHF6EXDBi8DVNJvrLE619vwypvG') &&
+          isSolanaAddress(acc.address)
         )
 
         if (linkedSolanaWallet) {

--- a/frontend/app/test-privy-solana/page.js
+++ b/frontend/app/test-privy-solana/page.js
@@ -3,10 +3,14 @@
 import React, { useMemo, useState } from 'react'
 import { usePrivy, useWallets } from '@privy-io/react-auth'
 
+function isSolanaChain(chainType) {
+  return typeof chainType === 'string' && chainType.toLowerCase().startsWith('solana')
+}
+
 function pickDefaultSolanaWallet(wallets) {
   return (
-    wallets.find(w => w.chainType === 'solana' && w.walletClientType === 'privy') ||
-    wallets.find(w => w.chainType === 'solana') ||
+    wallets.find(w => isSolanaChain(w.chainType) && w.walletClientType === 'privy') ||
+    wallets.find(w => isSolanaChain(w.chainType)) ||
     null
   )
 }
@@ -20,7 +24,7 @@ export default function TestPrivySolana() {
   const { wallets } = useWallets()
 
   const solWallets = useMemo(
-    () => wallets.filter(w => w.chainType === 'solana'),
+    () => wallets.filter(w => isSolanaChain(w.chainType)),
     [wallets]
   )
 


### PR DESCRIPTION
## Summary
- normalize Privy wallet discovery by checking for Solana chain prefixes and filtering out 0x addresses
- apply the robust detection helpers to the main lobby page and Solana test utilities so embedded wallets are surfaced reliably

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e604e9f52c833092f97ea53014dc73