### PR TITLE
Fix Privy config logging crash during hydration

### DIFF
--- a/components/providers/PrivyAuthProvider.js
+++ b/components/providers/PrivyAuthProvider.js
@@ -44,12 +44,38 @@ function ClientOnlyPrivyProvider({ children, appId, config, debugInfo }) {
     console.log('📋 App ID:', appId ? `${appId.substring(0, 10)}...` : 'MISSING')
     console.log('📋 Solana RPC:', debugInfo.solanaRpcUrl)
     console.log('📋 Solana WS:', debugInfo.solanaWsUrl)
-    console.log('📋 Config:', JSON.stringify({
-      appearance: config.appearance,
-      embeddedWallets: config.embeddedWallets,
-      externalWallets: config.externalWallets,
-      solanaChains: Object.keys(config.solana?.rpcs || {})
-    }, null, 2))
+
+    try {
+      const { appearance, embeddedWallets, externalWallets = {}, solana } = config || {}
+
+      const safeExternalWallets = Object.fromEntries(
+        Object.entries(externalWallets).map(([chain, walletConfig = {}]) => {
+          const connectors = walletConfig.connectors
+
+          if (Array.isArray(connectors)) {
+            return [
+              chain,
+              connectors.map((connector) => connector?.name || connector?.id || 'custom-connector')
+            ]
+          }
+
+          if (connectors && typeof connectors === 'object') {
+            return [chain, Object.keys(connectors)]
+          }
+
+          return [chain, []]
+        })
+      )
+
+      console.log('📋 Config:', JSON.stringify({
+        appearance,
+        embeddedWallets,
+        externalWallets: safeExternalWallets,
+        solanaChains: Object.keys(solana?.rpcs || {})
+      }, null, 2))
+    } catch (error) {
+      console.warn('⚠️ Unable to serialize Privy config for logging:', error)
+    }
   }, [config, appId, debugInfo])
 
   // Simple hydration check - no delays


### PR DESCRIPTION
## Summary
- guard the Privy client wrapper's debug logging so circular connector data no longer breaks rendering

## Testing
- npm run lint *(fails: pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e6729bc4ac833088f1a496e579dcdc