### PR TITLE
Restrict wallet handling to Privy embedded accounts

### DIFF
--- a/components/providers/PrivyAuthProvider.js
+++ b/components/providers/PrivyAuthProvider.js
@@ -1,7 +1,6 @@
 'use client'
 
 import { PrivyProvider } from '@privy-io/react-auth'
-import { toSolanaWalletConnectors } from '@privy-io/react-auth/solana'
 import { Component, useState, useEffect, useMemo } from 'react'
 
 // Error boundary for Privy-related errors
@@ -151,10 +150,10 @@ export default function PrivyAuthProvider({ children }) {
       showWalletUIs: true
     },
 
-    // 🎯 PRIVY 3.0: External Wallets - leverage Wallet Standard connectors
+    // ❌ Disable all external wallet connectors – embedded wallets only
     externalWallets: {
       solana: {
-        connectors: toSolanaWalletConnectors({ shouldAutoConnect: false })
+        connectors: []
       }
     },
 

--- a/frontend/components/providers/PrivyAuthProvider.js
+++ b/frontend/components/providers/PrivyAuthProvider.js
@@ -2,8 +2,6 @@
 
 import { PrivyProvider } from '@privy-io/react-auth'
 import { Component, useState, useEffect } from 'react'
-import { PhantomWalletAdapter } from '@solana/wallet-adapter-phantom'
-import { SolflareWalletAdapter } from '@solana/wallet-adapter-solflare'
 
 // Error boundary for Privy-related errors
 class PrivyErrorBoundary extends Component {
@@ -165,13 +163,11 @@ export default function PrivyAuthProvider({ children }) {
       }
     },
     
-    // 🎯 CRITICAL: External Wallets - SOLANA ONLY  
+    // ❌ Disable all external wallet connectors – embedded only
     externalWallets: {
-      // ✅ ONLY Solana external wallet connectors
       solana: {
-        wallets: ['phantom', 'solflare']
+        wallets: []
       }
-      // ❌ NO ethereum section = no MetaMask, WalletConnect, etc.
     },
     
     // 🎯 CRITICAL: supportedChains for v2.24.0 fundWallet compatibility


### PR DESCRIPTION
## Summary
- disable external Solana connectors in both Privy provider implementations so only embedded wallets are exposed
- filter wallet resolution logic on the landing page to use Privy-provided embedded wallets before paid arena joins
- align the legacy frontend flow with the same embedded-only wallet handling and logging

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e680f48e5883308c3dac91dd2e8566