### PR TITLE
Fix Privy Solana external wallet connector runtime error

### DIFF
--- a/components/providers/PrivyAuthProvider.js
+++ b/components/providers/PrivyAuthProvider.js
@@ -126,6 +126,15 @@ export default function PrivyAuthProvider({ children }) {
     [solanaChain, solanaRpcUrl, solanaWsUrl]
   )
 
+  const emptySolanaConnectors = useMemo(
+    () => ({
+      onMount: () => {},
+      onUnmount: () => {},
+      get: () => []
+    }),
+    []
+  )
+
   const config = {
     // UI Appearance
     appearance: {
@@ -153,7 +162,7 @@ export default function PrivyAuthProvider({ children }) {
     // ❌ Disable all external wallet connectors – embedded wallets only
     externalWallets: {
       solana: {
-        connectors: []
+        connectors: emptySolanaConnectors
       }
     },
 


### PR DESCRIPTION
## Summary
- provide a no-op Solana connector implementation when disabling external wallets so Privy no longer calls an undefined `onMount`

## Testing
- npm run dev *(fails: Next.js cannot resolve `@solana-program/memo` in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e684495b208330ba9b410c338e817b