### PR TITLE
Fix Privy embedded wallet detection for Solana fee signing

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -102,7 +102,7 @@ const isPrivyEmbeddedWallet = (wallet) => {
     return true
   }
 
-  if (!wallet.connectorType && clientType === 'embedded') {
+  if (!wallet.connectorType && clientType.includes('embedded')) {
     return true
   }
 


### PR DESCRIPTION
## Summary
- treat embedded Privy wallets with client types such as `embedded_wallet` as embedded
- allow embedded Solana wallets to be discovered for fee signing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6880f56248330887527718ea87c06